### PR TITLE
Shorter startup health checks for control and compute planes

### DIFF
--- a/infrastructure/modules/armonik/compute-plane.tf
+++ b/infrastructure/modules/armonik/compute-plane.tf
@@ -98,11 +98,11 @@ resource "kubernetes_deployment" "compute_plane" {
               path = "/startup"
               port = 1080
             }
-            initial_delay_seconds = 60
-            period_seconds        = 5
+            initial_delay_seconds = 1
+            period_seconds        = 3
             timeout_seconds       = 1
             success_threshold     = 1
-            failure_threshold     = 3 # the pod has (period_seconds x failure_threshold) seconds to finalize its startup
+            failure_threshold     = 20 # the pod has (period_seconds x failure_threshold) seconds to finalize its startup
           }
           env_from {
             config_map_ref {

--- a/infrastructure/modules/armonik/control-plane.tf
+++ b/infrastructure/modules/armonik/control-plane.tf
@@ -87,11 +87,11 @@ resource "kubernetes_deployment" "control_plane" {
             tcp_socket {
               port = 1080
             }
-            initial_delay_seconds = 60
-            period_seconds        = 5
+            initial_delay_seconds = 1
+            period_seconds        = 3
             timeout_seconds       = 1
             success_threshold     = 1
-            failure_threshold     = 3 # the pod has (period_seconds x failure_threshold) seconds to finalize its startup
+            failure_threshold     = 20 # the pod has (period_seconds x failure_threshold) seconds to finalize its startup
           }
           env_from {
             config_map_ref {


### PR DESCRIPTION
Control plane and Compute plane do not require anymore a minute to start. This PR changes the initial delay of the startup probe in order to let Kubernetes know that pods have properly started sooner.