### PR TITLE
Fix for k8s 1.24

### DIFF
--- a/infrastructure/modules/monitoring/fluent-bit/fluent-bit.tf
+++ b/infrastructure/modules/monitoring/fluent-bit/fluent-bit.tf
@@ -131,7 +131,7 @@ resource "kubernetes_daemonset" "fluent_bit" {
         host_network                     = true
         dns_policy                       = "ClusterFirstWithHostNet"
         termination_grace_period_seconds = 10
-        service_account_name             = kubernetes_service_account.fluent_bit.0.metadata.0.name
+        service_account_name             = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.name #kubernetes_service_account.fluent_bit.0.metadata.0.name
         toleration {
           key      = "node-role.kubernetes.io/master"
           operator = "Exists"

--- a/infrastructure/modules/monitoring/fluent-bit/service-account.tf
+++ b/infrastructure/modules/monitoring/fluent-bit/service-account.tf
@@ -1,9 +1,23 @@
 # Service account and role for Fluent-bit
-resource "kubernetes_service_account" "fluent_bit" {
+#resource "kubernetes_service_account" "fluent_bit" {
+#  count = (local.fluent_bit_is_daemonset ? 1 : 0)
+#  metadata {
+#    name      = "fluent-bit"
+#    namespace = var.namespace
+#  }
+#}
+
+## Issue: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724
+## This should be rolled back once the kubernetes provider for terraform has been updated.
+resource "kubernetes_manifest" "service_account_fluent_bit" {
   count = (local.fluent_bit_is_daemonset ? 1 : 0)
-  metadata {
-    name      = "fluent-bit"
-    namespace = var.namespace
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ServiceAccount"
+    metadata = {
+      name      = "fluent-bit"
+      namespace = var.namespace
+    }
   }
 }
 
@@ -35,7 +49,7 @@ resource "kubernetes_cluster_role_binding" "fluent_bit_role_binding" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.fluent_bit.0.metadata.0.name
-    namespace = kubernetes_service_account.fluent_bit.0.metadata.0.namespace
+    name      = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.name      #kubernetes_service_account.fluent_bit.0.metadata.0.name
+    namespace = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.namespace #kubernetes_service_account.fluent_bit.0.metadata.0.namespace
   }
 }


### PR DESCRIPTION
The Kubernetes provider for terraform does not work anymore on kubernetes 1.24: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724

This is a quick fix to make it work even without the provider fix.

-> Use plain old manifest for fluent bit SA