### PR TITLE
Only try to create namespace if not already created

### DIFF
--- a/infrastructure/quick-deploy/localhost/Makefile
+++ b/infrastructure/quick-deploy/localhost/Makefile
@@ -16,9 +16,9 @@ MONITORING_PARAMETERS_FILE?=$(CURRENT_DIR)/monitoring/generated/monitoring-outpu
 ####################################
 
 create-namespace:
-	kubectl create namespace $(ARMONIK_KUBERNETES_NAMESPACE) || true
-	kubectl create namespace $(KEDA_KUBERNETES_NAMESPACE) || true
-	kubectl create namespace $(METRICS_SERVER_KUBERNETES_NAMESPACE) || true
+	kubectl get namespace $(ARMONIK_KUBERNETES_NAMESPACE)  > /dev/null 2>&1 && echo "namespace : '$(ARMONIK_KUBERNETES_NAMESPACE)' is already created." || kubectl create namespace $(ARMONIK_KUBERNETES_NAMESPACE)
+	kubectl get namespace $(KEDA_KUBERNETES_NAMESPACE)  > /dev/null 2>&1 && echo "namespace : '$(KEDA_KUBERNETES_NAMESPACE)' is already created." || kubectl create namespace $(KEDA_KUBERNETES_NAMESPACE)
+	kubectl get namespace $(METRICS_SERVER_KUBERNETES_NAMESPACE)  > /dev/null 2>&1 &&  echo "namespace : '$(METRICS_SERVER_KUBERNETES_NAMESPACE)' is already created." || kubectl create namespace $(METRICS_SERVER_KUBERNETES_NAMESPACE)
 
 delete-namespace:
 	kubectl delete namespace $(ARMONIK_KUBERNETES_NAMESPACE) || true


### PR DESCRIPTION
During installation of armonik :
   Step create namespace: => you can have error message if namespaces already created.
It's not really an error but it is confusing for the user goal here is to avoid creation if namespace already created