### PR TITLE
fix: increase control plane error tolerance

### DIFF
--- a/infrastructure/modules/armonik/control-plane-configmap.tf
+++ b/infrastructure/modules/armonik/control-plane-configmap.tf
@@ -6,5 +6,6 @@ resource "kubernetes_config_map" "control_plane_config" {
   }
   data = {
     Submitter__DefaultPartition = (local.default_partition == null || local.default_partition == "" || !contains(local.partition_names, local.default_partition) ? (length(local.partition_names) > 0 ? local.partition_names[0] : "") : local.default_partition)
+    Submitter__MaxErrorAllowed  = "50"
   }
 }


### PR DESCRIPTION
This PR increases the number of errors allowed in the control plane before considering it unhealthy. This may allow to fix the issue with the stream test from Core not functionning.
