### PR TITLE
Parametrized configmaps

### DIFF
--- a/infrastructure/modules/armonik/compute-plane-confimap.tf
+++ b/infrastructure/modules/armonik/compute-plane-confimap.tf
@@ -4,10 +4,10 @@ resource "kubernetes_config_map" "compute_plane_config" {
     name      = "compute-plane-configmap"
     namespace = var.namespace
   }
-  data = {
+  data = merge(var.extra_conf.compute, {
     ComputePlane__WorkerChannel__Address    = "/cache/armonik_worker.sock"
     ComputePlane__WorkerChannel__SocketType = "unixdomainsocket"
     ComputePlane__AgentChannel__Address     = "/cache/armonik_agent.sock"
     ComputePlane__AgentChannel__SocketType  = "unixdomainsocket"
-  }
+  })
 }

--- a/infrastructure/modules/armonik/control-plane-configmap.tf
+++ b/infrastructure/modules/armonik/control-plane-configmap.tf
@@ -4,7 +4,7 @@ resource "kubernetes_config_map" "control_plane_config" {
     name      = "control-plane-configmap"
     namespace = var.namespace
   }
-  data = {
+  data = merge(var.extra_conf.control, {
     Submitter__DefaultPartition = (local.default_partition == null || local.default_partition == "" || !contains(local.partition_names, local.default_partition) ? (length(local.partition_names) > 0 ? local.partition_names[0] : "") : local.default_partition)
-  }
+  })
 }

--- a/infrastructure/modules/armonik/core-configmap.tf
+++ b/infrastructure/modules/armonik/core-configmap.tf
@@ -4,12 +4,10 @@ resource "kubernetes_config_map" "core_config" {
     name      = "core-configmap"
     namespace = var.namespace
   }
-  data = {
+  data = merge(var.extra_conf.core, {
     Components__TableStorage                   = "ArmoniK.Adapters.MongoDB.TableStorage"
     Components__ObjectStorage                  = "ArmoniK.Adapters.Redis.ObjectStorage"
     Components__QueueStorage                   = "ArmoniK.Adapters.Amqp.QueueStorage"
-    MongoDB__TableStorage__PollingDelayMin     = local.mongodb_polling_min_delay
-    MongoDB__TableStorage__PollingDelayMax     = local.mongodb_polling_max_delay
     MongoDB__Host                              = local.mongodb_host
     MongoDB__Port                              = local.mongodb_port
     MongoDB__CAFile                            = (local.mongodb_certificates_secret != "" ? "/mongodb/${local.mongodb_certificates_ca_filename}" : "")
@@ -39,5 +37,5 @@ resource "kubernetes_config_map" "core_config" {
     Amqp__QueueStorage__LockRefreshExtension   = "00:02:00"
     Authenticator__RequireAuthentication       = local.authentication_require_authentication
     Authenticator__RequireAuthorization        = local.authentication_require_authorization
-  }
+  })
 }

--- a/infrastructure/modules/armonik/locals.tf
+++ b/infrastructure/modules/armonik/locals.tf
@@ -114,10 +114,6 @@ locals {
   # ingress ports
   ingress_ports = var.ingress != null ? distinct(compact([var.ingress.http_port, var.ingress.grpc_port])) : []
 
-  # Polling delay to MongoDB
-  mongodb_polling_min_delay = try(var.mongodb_polling_delay.min_polling_delay, "00:00:01")
-  mongodb_polling_max_delay = try(var.mongodb_polling_delay.max_polling_delay, "00:05:00")
-
   # Credentials
   credentials = {
     for key, value in {

--- a/infrastructure/modules/armonik/log-configmap.tf
+++ b/infrastructure/modules/armonik/log-configmap.tf
@@ -7,10 +7,10 @@ resource "kubernetes_config_map" "log_config" {
     name      = "log-configmap"
     namespace = var.namespace
   }
-  data = {
+  data = merge(var.extra_conf.log, {
     "Serilog__MinimumLevel" : var.logging_level,
     "Serilog__MinimumLevel__Override__Microsoft.AspNetCore.Hosting.Diagnostics" : local.logging_level_routing,
     "Serilog__MinimumLevel__Override__Microsoft.AspNetCore.Routing.EndpointMiddleware" : local.logging_level_routing,
     "Serilog__MinimumLevel__Override__Serilog.AspNetCore.RequestLoggingMiddleware" : local.logging_level_routing,
-  }
+  })
 }

--- a/infrastructure/modules/armonik/polling-agent-configmap.tf
+++ b/infrastructure/modules/armonik/polling-agent-configmap.tf
@@ -4,7 +4,7 @@ resource "kubernetes_config_map" "polling_agent_config" {
     name      = "polling-agent-configmap"
     namespace = var.namespace
   }
-  data = {
+  data = merge(var.extra_conf.polling, {
     Components__TableStorage       = "ArmoniK.Adapters.MongoDB.TableStorage"
     Components__ObjectStorage      = "ArmoniK.Adapters.Redis.ObjectStorage"
     Components__QueueStorage       = "ArmoniK.Adapters.Amqp.QueueStorage"
@@ -13,5 +13,5 @@ resource "kubernetes_config_map" "polling_agent_config" {
     InitWorker__WorkerCheckDelay   = "00:00:10" # TODO: make it a variable
     Amqp__LinkCredit               = "2"
     Pollster__GraceDelay           = "00:00:15"
-  }
+  })
 }

--- a/infrastructure/modules/armonik/variables.tf
+++ b/infrastructure/modules/armonik/variables.tf
@@ -75,14 +75,25 @@ variable "ingress" {
   }
 }
 
-# Polling delay to MongoDB
-# according to the size of the task and/or the application
-variable "mongodb_polling_delay" {
-  description = "Polling delay to MongoDB according to the size of the task and/or the application"
+# Extra configuration
+variable "extra_conf" {
+  description = "Add extra configuration in the configmaps"
   type = object({
-    min_polling_delay = string
-    max_polling_delay = string
+    compute = map(string)
+    control = map(string)
+    core    = map(string)
+    log     = map(string)
+    polling = map(string)
+    worker  = map(string)
   })
+  default = {
+    compute = {}
+    control = {}
+    core    = {}
+    log     = {}
+    polling = {}
+    worker  = {}
+  }
 }
 
 # Job to insert partitions in the database

--- a/infrastructure/modules/armonik/worker-configmap.tf
+++ b/infrastructure/modules/armonik/worker-configmap.tf
@@ -4,13 +4,13 @@ resource "kubernetes_config_map" "worker_config" {
     name      = "worker-configmap"
     namespace = var.namespace
   }
-  data = {
+  data = merge(var.extra_conf.worker, {
     target_data_path           = "/data"
     S3Storage__ServiceURL      = local.service_url
     S3Storage__AccessKeyId     = local.access_key_id
     S3Storage__SecretAccessKey = local.secret_access_key
     S3Storage__BucketName      = local.name
     FileStorageType            = local.check_file_storage_type
-  }
+  })
   depends_on = [kubernetes_service.control_plane]
 }

--- a/infrastructure/quick-deploy/aws/all/armonik.tf
+++ b/infrastructure/quick-deploy/aws/all/armonik.tf
@@ -1,11 +1,11 @@
 module "armonik" {
-  source                = "../../../modules/armonik"
-  working_dir           = "${path.root}/../../.."
-  namespace             = local.namespace
-  logging_level         = var.logging_level
-  storage_endpoint_url  = local.storage_endpoint_url
-  monitoring            = local.monitoring
-  extra_conf            = var.extra_conf
+  source               = "../../../modules/armonik"
+  working_dir          = "${path.root}/../../.."
+  namespace            = local.namespace
+  logging_level        = var.logging_level
+  storage_endpoint_url = local.storage_endpoint_url
+  monitoring           = local.monitoring
+  extra_conf           = var.extra_conf
   // If compute plane has no partition data, provides a default
   // but always overrides the images
   compute_plane = { for k, v in var.compute_plane : k => merge({

--- a/infrastructure/quick-deploy/aws/all/armonik.tf
+++ b/infrastructure/quick-deploy/aws/all/armonik.tf
@@ -3,9 +3,9 @@ module "armonik" {
   working_dir           = "${path.root}/../../.."
   namespace             = local.namespace
   logging_level         = var.logging_level
-  mongodb_polling_delay = var.mongodb_polling_delay
   storage_endpoint_url  = local.storage_endpoint_url
   monitoring            = local.monitoring
+  extra_conf            = var.extra_conf
   // If compute plane has no partition data, provides a default
   // but always overrides the images
   compute_plane = { for k, v in var.compute_plane : k => merge({

--- a/infrastructure/quick-deploy/aws/all/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/all/parameters.tfvars
@@ -301,3 +301,10 @@ authentication = {
   image = "rtsp/mongosh"
   tag   = "1.5.4"
 }
+
+extra_conf = {
+  core = {
+    MongoDB__TableStorage__PollingDelayMin = "00:00:01"
+    MongoDB__TableStorage__PollingDelayMax = "00:00:10"
+  }
+}

--- a/infrastructure/quick-deploy/aws/all/variables.tf
+++ b/infrastructure/quick-deploy/aws/all/variables.tf
@@ -394,14 +394,16 @@ variable "cloudwatch" {
   default = {}
 }
 
-
-# Polling delay to MongoDB
-# according to the size of the task and/or the application
-variable "mongodb_polling_delay" {
-  description = "Polling delay to MongoDB according to the size of the task and/or the application"
+# Extra configuration
+variable "extra_conf" {
+  description = "Add extra configuration in the configmaps"
   type = object({
-    min_polling_delay = optional(string, "00:00:01")
-    max_polling_delay = optional(string, "00:00:15")
+    compute = optional(map(string), {})
+    control = optional(map(string), {})
+    core    = optional(map(string), {})
+    log     = optional(map(string), {})
+    polling = optional(map(string), {})
+    worker  = optional(map(string), {})
   })
   default = {}
 }

--- a/infrastructure/quick-deploy/aws/armonik/main.tf
+++ b/infrastructure/quick-deploy/aws/armonik/main.tf
@@ -1,10 +1,10 @@
 module "armonik" {
-  source                = "../../../modules/armonik"
-  working_dir           = "${path.root}/../../.."
-  namespace             = var.namespace
-  logging_level         = var.logging_level
-  storage_endpoint_url  = var.storage_endpoint_url
-  monitoring            = var.monitoring
+  source               = "../../../modules/armonik"
+  working_dir          = "${path.root}/../../.."
+  namespace            = var.namespace
+  logging_level        = var.logging_level
+  storage_endpoint_url = var.storage_endpoint_url
+  monitoring           = var.monitoring
   extra_conf = {
     compute = try(var.extra_conf.compute, {})
     control = try(var.extra_conf.control, {})

--- a/infrastructure/quick-deploy/aws/armonik/main.tf
+++ b/infrastructure/quick-deploy/aws/armonik/main.tf
@@ -3,9 +3,16 @@ module "armonik" {
   working_dir           = "${path.root}/../../.."
   namespace             = var.namespace
   logging_level         = var.logging_level
-  mongodb_polling_delay = var.mongodb_polling_delay
   storage_endpoint_url  = var.storage_endpoint_url
   monitoring            = var.monitoring
+  extra_conf = {
+    compute = try(var.extra_conf.compute, {})
+    control = try(var.extra_conf.control, {})
+    core    = try(var.extra_conf.core, {})
+    log     = try(var.extra_conf.log, {})
+    polling = try(var.extra_conf.polling, {})
+    worker  = try(var.extra_conf.worker, {})
+  }
   compute_plane = { for k, v in var.compute_plane : k => merge({
     partition_data = {
       priority              = 1

--- a/infrastructure/quick-deploy/aws/armonik/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/armonik/parameters.tfvars
@@ -16,13 +16,6 @@ namespace = "armonik"
 # Logging level
 logging_level = "Information"
 
-# Polling delay to MongoDB
-# according to the size of the task and/or the application
-mongodb_polling_delay = {
-  min_polling_delay = "00:00:01"
-  max_polling_delay = "00:00:10"
-}
-
 # Job to insert partitions in the database
 job_partitions_in_database = {
   name               = "job-partitions-in-database"
@@ -214,4 +207,11 @@ authentication = {
   authentication_datafile = ""
   require_authentication  = false
   require_authorization   = false
+}
+
+extra_conf = {
+  core = {
+    MongoDB__TableStorage__PollingDelayMin = "00:00:01"
+    MongoDB__TableStorage__PollingDelayMax = "00:00:10"
+  }
 }

--- a/infrastructure/quick-deploy/aws/armonik/variables.tf
+++ b/infrastructure/quick-deploy/aws/armonik/variables.tf
@@ -54,14 +54,20 @@ variable "monitoring" {
   default     = {}
 }
 
-# Polling delay to MongoDB
-# according to the size of the task and/or the application
-variable "mongodb_polling_delay" {
-  description = "Polling delay to MongoDB according to the size of the task and/or the application"
-  type = object({
-    min_polling_delay = string
-    max_polling_delay = string
-  })
+
+# Extra configuration
+variable "extra_conf" {
+  description = "Add extra configuration in the configmaps"
+  #type = object({
+  #  compute = optional(map(string), {})
+  #  control = optional(map(string), {})
+  #  core    = optional(map(string), {})
+  #  log     = optional(map(string), {})
+  #  polling = optional(map(string), {})
+  #  worker  = optional(map(string), {})
+  #})
+  type    = any
+  default = {}
 }
 
 # Job to insert partitions in the database

--- a/infrastructure/quick-deploy/aws/eks/versions.tf
+++ b/infrastructure/quick-deploy/aws/eks/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.13.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/infrastructure/quick-deploy/aws/monitoring/versions.tf
+++ b/infrastructure/quick-deploy/aws/monitoring/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.13.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/infrastructure/quick-deploy/aws/storage/versions.tf
+++ b/infrastructure/quick-deploy/aws/storage/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.13.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/infrastructure/quick-deploy/localhost/all/armonik.tf
+++ b/infrastructure/quick-deploy/localhost/all/armonik.tf
@@ -1,11 +1,11 @@
 module "armonik" {
-  source                = "../../../modules/armonik"
-  working_dir           = "${path.root}/../../.."
-  namespace             = local.namespace
-  logging_level         = var.logging_level
-  storage_endpoint_url  = local.storage_endpoint_url
-  monitoring            = local.monitoring
-  extra_conf            = var.extra_conf
+  source               = "../../../modules/armonik"
+  working_dir          = "${path.root}/../../.."
+  namespace            = local.namespace
+  logging_level        = var.logging_level
+  storage_endpoint_url = local.storage_endpoint_url
+  monitoring           = local.monitoring
+  extra_conf           = var.extra_conf
   // If compute plane has no partition data, provides a default
   // but always overrides the images
   compute_plane = { for k, v in var.compute_plane : k => merge({

--- a/infrastructure/quick-deploy/localhost/all/armonik.tf
+++ b/infrastructure/quick-deploy/localhost/all/armonik.tf
@@ -3,9 +3,9 @@ module "armonik" {
   working_dir           = "${path.root}/../../.."
   namespace             = local.namespace
   logging_level         = var.logging_level
-  mongodb_polling_delay = var.mongodb_polling_delay
   storage_endpoint_url  = local.storage_endpoint_url
   monitoring            = local.monitoring
+  extra_conf            = var.extra_conf
   // If compute plane has no partition data, provides a default
   // but always overrides the images
   compute_plane = { for k, v in var.compute_plane : k => merge({

--- a/infrastructure/quick-deploy/localhost/all/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/all/parameters.tfvars
@@ -1,5 +1,5 @@
 # Uncomment to deploy metrics server
-#metrics_server  ={}
+#metrics_server = {}
 
 # Parameters for ActiveMQ
 activemq = {
@@ -178,4 +178,11 @@ ingress = {
 authentication = {
   image = "rtsp/mongosh"
   tag   = "1.5.4"
+}
+
+extra_conf = {
+  core = {
+    MongoDB__TableStorage__PollingDelayMin = "00:00:01"
+    MongoDB__TableStorage__PollingDelayMax = "00:00:10"
+  }
 }

--- a/infrastructure/quick-deploy/localhost/all/variables.tf
+++ b/infrastructure/quick-deploy/localhost/all/variables.tf
@@ -202,14 +202,16 @@ variable "fluent_bit" {
   })
 }
 
-
-# Polling delay to MongoDB
-# according to the size of the task and/or the application
-variable "mongodb_polling_delay" {
-  description = "Polling delay to MongoDB according to the size of the task and/or the application"
+# Extra configuration
+variable "extra_conf" {
+  description = "Add extra configuration in the configmaps"
   type = object({
-    min_polling_delay = optional(string, "00:00:01")
-    max_polling_delay = optional(string, "00:00:15")
+    compute = optional(map(string), {})
+    control = optional(map(string), {})
+    core    = optional(map(string), {})
+    log     = optional(map(string), {})
+    polling = optional(map(string), {})
+    worker  = optional(map(string), {})
   })
   default = {}
 }

--- a/infrastructure/quick-deploy/localhost/armonik/main.tf
+++ b/infrastructure/quick-deploy/localhost/armonik/main.tf
@@ -1,10 +1,10 @@
 module "armonik" {
-  source                = "../../../modules/armonik"
-  working_dir           = "${path.root}/../../.."
-  namespace             = var.namespace
-  logging_level         = var.logging_level
-  storage_endpoint_url  = var.storage_endpoint_url
-  monitoring            = var.monitoring
+  source               = "../../../modules/armonik"
+  working_dir          = "${path.root}/../../.."
+  namespace            = var.namespace
+  logging_level        = var.logging_level
+  storage_endpoint_url = var.storage_endpoint_url
+  monitoring           = var.monitoring
   extra_conf = {
     compute = try(var.extra_conf.compute, {})
     control = try(var.extra_conf.control, {})

--- a/infrastructure/quick-deploy/localhost/armonik/main.tf
+++ b/infrastructure/quick-deploy/localhost/armonik/main.tf
@@ -3,9 +3,16 @@ module "armonik" {
   working_dir           = "${path.root}/../../.."
   namespace             = var.namespace
   logging_level         = var.logging_level
-  mongodb_polling_delay = var.mongodb_polling_delay
   storage_endpoint_url  = var.storage_endpoint_url
   monitoring            = var.monitoring
+  extra_conf = {
+    compute = try(var.extra_conf.compute, {})
+    control = try(var.extra_conf.control, {})
+    core    = try(var.extra_conf.core, {})
+    log     = try(var.extra_conf.log, {})
+    polling = try(var.extra_conf.polling, {})
+    worker  = try(var.extra_conf.worker, {})
+  }
   compute_plane = { for k, v in var.compute_plane : k => merge({
     partition_data = {
       priority              = 1

--- a/infrastructure/quick-deploy/localhost/armonik/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/armonik/parameters.tfvars
@@ -4,13 +4,6 @@ namespace = "armonik"
 # Logging level
 logging_level = "Information"
 
-# Polling delay to MongoDB
-# according to the size of the task and/or the application
-mongodb_polling_delay = {
-  min_polling_delay = "00:00:01"
-  max_polling_delay = "00:00:10"
-}
-
 # Job to insert partitions in the database
 job_partitions_in_database = {
   name               = "job-partitions-in-database"
@@ -209,4 +202,11 @@ authentication = {
   authentication_datafile = ""
   require_authentication  = false
   require_authorization   = false
+}
+
+extra_conf = {
+  core = {
+    MongoDB__TableStorage__PollingDelayMin = "00:00:01"
+    MongoDB__TableStorage__PollingDelayMax = "00:00:10"
+  }
 }

--- a/infrastructure/quick-deploy/localhost/armonik/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/armonik/parameters.tfvars
@@ -209,4 +209,7 @@ extra_conf = {
     MongoDB__TableStorage__PollingDelayMin = "00:00:01"
     MongoDB__TableStorage__PollingDelayMax = "00:00:10"
   }
+  control = {
+    Submitter__MaxErrorAllowed = 50
+  }
 }

--- a/infrastructure/quick-deploy/localhost/armonik/variables.tf
+++ b/infrastructure/quick-deploy/localhost/armonik/variables.tf
@@ -47,14 +47,19 @@ variable "monitoring" {
   default     = {}
 }
 
-# Polling delay to MongoDB
-# according to the size of the task and/or the application
-variable "mongodb_polling_delay" {
-  description = "Polling delay to MongoDB according to the size of the task and/or the application"
-  type = object({
-    min_polling_delay = string
-    max_polling_delay = string
-  })
+# Extra configuration
+variable "extra_conf" {
+  description = "Add extra configuration in the configmaps"
+  #type = object({
+  #  compute = optional(map(string), {})
+  #  control = optional(map(string), {})
+  #  core    = optional(map(string), {})
+  #  log     = optional(map(string), {})
+  #  polling = optional(map(string), {})
+  #  worker  = optional(map(string), {})
+  #})
+  type    = any
+  default = {}
 }
 
 # Job to insert partitions in the database

--- a/infrastructure/quick-deploy/localhost/armonik/versions.tf
+++ b/infrastructure/quick-deploy/localhost/armonik/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.13.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/infrastructure/quick-deploy/localhost/keda/versions.tf
+++ b/infrastructure/quick-deploy/localhost/keda/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.13.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/infrastructure/quick-deploy/localhost/metrics-server/versions.tf
+++ b/infrastructure/quick-deploy/localhost/metrics-server/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.13.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/infrastructure/quick-deploy/localhost/monitoring/versions.tf
+++ b/infrastructure/quick-deploy/localhost/monitoring/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.13.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/infrastructure/quick-deploy/localhost/storage/versions.tf
+++ b/infrastructure/quick-deploy/localhost/storage/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.13.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"


### PR DESCRIPTION
This makes it possible to add extra configuration into all the ArmoniK configmaps. This is an easy way to adjust behavior of the deployment without needed to alter the terraform code. As an example, it integrates #834 for localhost deployment.