### PR TITLE
Fix namespaces in all-in-one deployments

### DIFF
--- a/infrastructure/quick-deploy/aws/all/eks.tf
+++ b/infrastructure/quick-deploy/aws/all/eks.tf
@@ -36,23 +36,14 @@ module "eks" {
   eks_worker_groups             = var.eks_worker_groups
 }
 
-resource "null_resource" "eks_namespace" {
-  triggers = {
-    namespace = var.namespace
-  }
-
-  provisioner "local-exec" {
-    command = "kubectl create namespace ${self.triggers.namespace}"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "kubectl delete namespace ${self.triggers.namespace}"
+resource "kubernetes_namespace" "armonik" {
+  metadata {
+    name = var.namespace
   }
 
   depends_on = [module.eks]
 }
 
 locals {
-  namespace = null_resource.eks_namespace.triggers.namespace
+  namespace = kubernetes_namespace.armonik.metadata[0].name
 }

--- a/infrastructure/quick-deploy/localhost/all/common.tf
+++ b/infrastructure/quick-deploy/localhost/all/common.tf
@@ -5,7 +5,13 @@ resource "random_string" "prefix" {
   numeric = true
 }
 
+resource "kubernetes_namespace" "armonik" {
+  metadata {
+    name = var.namespace
+  }
+}
+
 locals {
   prefix    = can(coalesce(var.prefix)) ? var.prefix : "armonik-${random_string.prefix.result}"
-  namespace = var.namespace
+  namespace = kubernetes_namespace.armonik.metadata[0].name
 }

--- a/infrastructure/quick-deploy/localhost/all/storage.tf
+++ b/infrastructure/quick-deploy/localhost/all/storage.tf
@@ -1,7 +1,7 @@
 # ActiveMQ
 module "activemq" {
   source      = "../../../modules/onpremise-storage/activemq"
-  namespace   = var.namespace
+  namespace   = local.namespace
   working_dir = "${path.root}/../../.."
   activemq = {
     image              = var.activemq.image_name
@@ -14,7 +14,7 @@ module "activemq" {
 # MongoDB
 module "mongodb" {
   source      = "../../../modules/onpremise-storage/mongodb"
-  namespace   = var.namespace
+  namespace   = local.namespace
   working_dir = "${path.root}/../../.."
   mongodb = {
     image              = var.mongodb.image_name
@@ -28,7 +28,7 @@ module "mongodb" {
 # Redis
 module "redis" {
   source      = "../../../modules/onpremise-storage/redis"
-  namespace   = var.namespace
+  namespace   = local.namespace
   working_dir = "${path.root}/../../.."
   redis = {
     image              = var.redis.image_name


### PR DESCRIPTION
All-in-one local deployments was not creating the namespace. This fixes that.