### PR TITLE
Fix default_secret_name is empty in service account

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
     - name: Install K3s
       shell: bash
       run: |
-        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.23.8+k3s1" sh -s - --write-kubeconfig-mode 644 --docker --write-kubeconfig ~/.kube/config
+        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.25.6+k3s1" sh -s - --write-kubeconfig-mode 644 --docker --write-kubeconfig ~/.kube/config
 
     - name: Set the name path of the shared storage
       id: sethostpath

--- a/infrastructure/modules/monitoring/fluent-bit/fluent-bit.tf
+++ b/infrastructure/modules/monitoring/fluent-bit/fluent-bit.tf
@@ -131,8 +131,9 @@ resource "kubernetes_daemonset" "fluent_bit" {
         host_network                     = true
         dns_policy                       = "ClusterFirstWithHostNet"
         termination_grace_period_seconds = 10
-        service_account_name             = kubernetes_service_account.fluent_bit.0.metadata.0.name
-        #service_account_name             = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.name
+        # For Kubernetes 1.23 and later, otherwise use kubernetes_manifest
+        #service_account_name             = kubernetes_service_account.fluent_bit.0.metadata.0.name
+        service_account_name = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.name
         toleration {
           key      = "node-role.kubernetes.io/master"
           operator = "Exists"

--- a/infrastructure/modules/monitoring/fluent-bit/service-account.tf
+++ b/infrastructure/modules/monitoring/fluent-bit/service-account.tf
@@ -6,9 +6,6 @@
     name      = "fluent-bit"
     namespace = var.namespace
   }
-  secret {
-    name = ""
-  }
 }
 */
 

--- a/infrastructure/modules/monitoring/fluent-bit/service-account.tf
+++ b/infrastructure/modules/monitoring/fluent-bit/service-account.tf
@@ -1,13 +1,17 @@
 # Service account and role for Fluent-bit
-resource "kubernetes_service_account" "fluent_bit" {
+# For Kubernetes 1.23 and later, otherwise use kubernetes_manifest
+/*resource "kubernetes_service_account" "fluent_bit" {
   count = (local.fluent_bit_is_daemonset ? 1 : 0)
   metadata {
     name      = "fluent-bit"
     namespace = var.namespace
   }
+  secret {
+    name = ""
+  }
 }
+*/
 
-/*
 ## Issue: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724
 ## This should be rolled back once the kubernetes provider for terraform has been updated.
 resource "kubernetes_manifest" "service_account_fluent_bit" {
@@ -21,7 +25,6 @@ resource "kubernetes_manifest" "service_account_fluent_bit" {
     }
   }
 }
-*/
 
 resource "kubernetes_cluster_role" "fluent_bit_role" {
   count = (local.fluent_bit_is_daemonset ? 1 : 0)
@@ -50,10 +53,11 @@ resource "kubernetes_cluster_role_binding" "fluent_bit_role_binding" {
     name      = kubernetes_cluster_role.fluent_bit_role.0.metadata.0.name
   }
   subject {
-    kind      = "ServiceAccount"
-    name      = kubernetes_service_account.fluent_bit.0.metadata.0.name
-    namespace = kubernetes_service_account.fluent_bit.0.metadata.0.namespace
-    #name      = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.name
-    #namespace = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.namespace
+    kind = "ServiceAccount"
+    # For Kubernetes 1.23 and later
+    #name      = kubernetes_service_account.fluent_bit.0.metadata.0.name
+    #namespace = kubernetes_service_account.fluent_bit.0.metadata.0.namespace
+    name      = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.name
+    namespace = kubernetes_manifest.service_account_fluent_bit.0.manifest.metadata.namespace
   }
 }

--- a/infrastructure/quick-deploy/localhost/docs/k3s.md
+++ b/infrastructure/quick-deploy/localhost/docs/k3s.md
@@ -21,7 +21,7 @@ distribution.
 Install K3s as follows:
 
 ```bash
-curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.23.8+k3s1" sh -s - --write-kubeconfig-mode 644 --docker --write-kubeconfig ~/.kube/config
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.25.6+k3s1" sh -s - --write-kubeconfig-mode 644 --docker --write-kubeconfig ~/.kube/config
 ```
 
 # Uninstall Kubernetes


### PR DESCRIPTION
Fix default_secret_name is empty in service account of kubernetes 1.24 and latre