### PR TITLE
fix creation date tag value : month/minute

### DIFF
--- a/infrastructure/quick-deploy/aws/all/common.tf
+++ b/infrastructure/quick-deploy/aws/all/common.tf
@@ -20,7 +20,7 @@ locals {
 
 # this external provider is used to get date during the plan step.
 data "external" "static_timestamp" {
-  program = ["date", "+{ \"creation_date\": \"%Y/%M/%d %T\" }"]
+  program = ["date", "+{ \"creation_date\": \"%Y/%m/%d %T\" }"]
 }
 
 # this resource is just used to prevent change of the creation_date during successive 'terraform apply'

--- a/infrastructure/quick-deploy/aws/eks/locals.tf
+++ b/infrastructure/quick-deploy/aws/eks/locals.tf
@@ -29,7 +29,7 @@ locals {
 
 # this external provider is used to get date during the plan step.
 data "external" "static_timestamp" {
-  program = ["date", "+{ \"creation_date\": \"%Y/%M/%d %T\" }"]
+  program = ["date", "+{ \"creation_date\": \"%Y/%m/%d %T\" }"]
 }
 
 # this resource is just used to prevent change of the creation_date during successive 'terraform apply'


### PR DESCRIPTION
the creation_date tag used in all deployed resource was using a incorrect time format :
minute instead month
in date format M is for minute, m is for month
fix is to replace M => m 
if you need to test with linux command line : 
before : date +"{ creation_date: %Y/%**M**/%d %T }"
after    : date +"{ creation_date: %Y/%**m**/%d %T }"