### PR TITLE
Add dependency to Keda

### DIFF
--- a/infrastructure/modules/armonik/compute-plane-hpa.tf
+++ b/infrastructure/modules/armonik/compute-plane-hpa.tf
@@ -66,6 +66,14 @@ resource "helm_release" "keda_hpa_compute_plane" {
     name  = "behavior.periodSeconds"
     value = try(var.compute_plane[each.key].hpa.behavior.period_seconds, 15)
   }
+  set {
+    name  = "kedaChartName"
+    value = var.keda_chart_name
+  }
+  set {
+    name  = "metricsServerChartName"
+    value = var.metrics_server_chart_name
+  }
 
   values = [
     yamlencode(local.compute_plane_triggers[each.key]),

--- a/infrastructure/modules/armonik/compute-plane-hpa.tf
+++ b/infrastructure/modules/armonik/compute-plane-hpa.tf
@@ -66,6 +66,8 @@ resource "helm_release" "keda_hpa_compute_plane" {
     name  = "behavior.periodSeconds"
     value = try(var.compute_plane[each.key].hpa.behavior.period_seconds, 15)
   }
+
+  # Forces the dependency on the Keda and Metrics Server Helm charts
   set {
     name  = "kedaChartName"
     value = var.keda_chart_name

--- a/infrastructure/modules/armonik/control-plane-hpa.tf
+++ b/infrastructure/modules/armonik/control-plane-hpa.tf
@@ -65,6 +65,8 @@ resource "helm_release" "keda_hpa_control_plane" {
     name  = "behavior.periodSeconds"
     value = try(var.control_plane.hpa.behavior.period_seconds, 15)
   }
+
+  # Forces the dependency on the Keda and Metrics Server Helm charts
   set {
     name  = "kedaChartName"
     value = var.keda_chart_name

--- a/infrastructure/modules/armonik/control-plane-hpa.tf
+++ b/infrastructure/modules/armonik/control-plane-hpa.tf
@@ -65,6 +65,14 @@ resource "helm_release" "keda_hpa_control_plane" {
     name  = "behavior.periodSeconds"
     value = try(var.control_plane.hpa.behavior.period_seconds, 15)
   }
+  set {
+    name  = "kedaChartName"
+    value = var.keda_chart_name
+  }
+  set {
+    name  = "metricsServerChartName"
+    value = var.metrics_server_chart_name
+  }
 
   values = [
     yamlencode(local.control_plane_triggers),

--- a/infrastructure/modules/armonik/variables.tf
+++ b/infrastructure/modules/armonik/variables.tf
@@ -343,3 +343,15 @@ variable "s3_secret_name" {
   type        = string
   default     = "s3"
 }
+
+variable "keda_chart_name" {
+  description = "Name of the Keda Helm chart"
+  type        = string
+  default     = "keda"
+}
+
+variable "metrics_server_chart_name" {
+  description = "Name of the metrics-server Helm chart"
+  type        = string
+  default     = "metrics-server"
+}

--- a/infrastructure/modules/monitoring/keda/outputs.tf
+++ b/infrastructure/modules/monitoring/keda/outputs.tf
@@ -1,3 +1,5 @@
 output "keda" {
-  value = {}
+  value = {
+    chart_name = helm_release.keda.name
+  }
 }

--- a/infrastructure/modules/monitoring/metrics-server/outputs.tf
+++ b/infrastructure/modules/monitoring/metrics-server/outputs.tf
@@ -1,3 +1,5 @@
 output "metrics_server" {
-  value = {}
+  value = {
+    chart_name = helm_release.metrics_server.name
+  }
 }

--- a/infrastructure/modules/onpremise-storage/mongodb/outputs.tf
+++ b/infrastructure/modules/onpremise-storage/mongodb/outputs.tf
@@ -12,6 +12,9 @@ output "port" {
 output "url" {
   description = "URL of MongoDB server"
   value       = local.mongodb_url
+  depends_on = [
+    kubernetes_deployment.mongodb
+  ]
 }
 
 output "number_of_replicas" {

--- a/infrastructure/quick-deploy/aws/all/armonik.tf
+++ b/infrastructure/quick-deploy/aws/all/armonik.tf
@@ -71,4 +71,8 @@ module "armonik" {
     image = local.ecr_images["${var.authentication.image}:${try(coalesce(var.authentication.tag), "")}"].name
     tag   = local.ecr_images["${var.authentication.image}:${try(coalesce(var.authentication.tag), "")}"].tag
   })
+
+  # Force the dependency on Keda and metrics-server for the HPA
+  keda_chart_name           = module.keda.keda.chart_name
+  metrics_server_chart_name = concat(module.metrics_server[*].metrics_server.chart_name, ["metrics-server"])[0]
 }

--- a/infrastructure/quick-deploy/localhost/all/armonik.tf
+++ b/infrastructure/quick-deploy/localhost/all/armonik.tf
@@ -65,4 +65,8 @@ module "armonik" {
   authentication = merge(var.authentication, {
     tag = try(coalesce(var.authentication.tag), local.default_tags[var.authentication.image])
   })
+
+  # Force the dependency on Keda and metrics-server for the HPA
+  keda_chart_name           = module.keda.keda.chart_name
+  metrics_server_chart_name = concat(module.metrics_server[*].metrics_server.chart_name, ["metrics-server"])[0]
 }


### PR DESCRIPTION
HPAs do not depend on Keda or prometheus. This PR adds a terraform dependency between Keda and the HPAs.