### PR TITLE
Al/update infra from v2.12.0 to v2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 ## [main](https://github.com/aneoconsulting/armonik/tree/main)
 
+
+## [v2.12.1](https://github.com/aneoconsulting/armonik/tree/v2.12.0) (2023-04-06)
+Changed
+-
+
+* Upgrade versions of docker images for ArmoniK (see [versions.tfvars.json](./versions.tfvars.json)):
+  * Core version from `0.12.2` to `0.12.3`.
+  * Extension C# version from `0.9.2` to `0.9.4`.
+* Samples version from `v2.12.0` to `v2.12.1`
+
+Fixed
+- 
+
+* Fix issue with AWSSDK.SecurityToken [#145](https://github.com/aneoconsulting/ArmoniK.Extensions.Csharp/pull/145)
+
 ## [v2.12.0](https://github.com/aneoconsulting/armonik/tree/v2.12.0) (2023-03-29)
 
 Changed

--- a/armonik-versions.txt
+++ b/armonik-versions.txt
@@ -1,4 +1,4 @@
-core=0.12.2
+core=0.12.3
 worker=0.9.2
 admin-gui=0.9.0
 samples=v2.12.0

--- a/armonik-versions.txt
+++ b/armonik-versions.txt
@@ -1,4 +1,4 @@
 core=0.12.3
-worker=0.9.2
+worker=0.9.4
 admin-gui=0.9.0
 samples=v2.12.0

--- a/armonik-versions.txt
+++ b/armonik-versions.txt
@@ -1,4 +1,4 @@
 core=0.12.3
 worker=0.9.4
 admin-gui=0.9.0
-samples=v2.12.0
+samples=v2.12.1

--- a/infrastructure/quick-deploy/aws/armonik/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/armonik/parameters.tfvars
@@ -33,7 +33,7 @@ control_plane = {
   service_type      = "ClusterIP"
   replicas          = 1
   image             = "125796369274.dkr.ecr.eu-west-3.amazonaws.com/armonik-control-plane"
-  tag               = "0.12.2"
+  tag               = "0.12.3"
   image_pull_policy = "IfNotPresent"
   port              = 5001
   limits = {
@@ -146,7 +146,7 @@ compute_plane = {
     # ArmoniK polling agent
     polling_agent = {
       image             = "125796369274.dkr.ecr.eu-west-3.amazonaws.com/armonik-polling-agent"
-      tag               = "0.12.2"
+      tag               = "0.12.3"
       image_pull_policy = "IfNotPresent"
       limits = {
         cpu    = "2000m"

--- a/infrastructure/quick-deploy/aws/armonik/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/armonik/parameters.tfvars
@@ -162,7 +162,7 @@ compute_plane = {
       {
         name              = "worker"
         image             = "125796369274.dkr.ecr.eu-west-3.amazonaws.com/armonik-worker"
-        tag               = "0.9.2"
+        tag               = "0.9.4"
         image_pull_policy = "IfNotPresent"
         limits = {
           cpu    = "1000m"

--- a/infrastructure/quick-deploy/aws/ecr/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/ecr/parameters.tfvars
@@ -58,7 +58,7 @@ ecr = {
     {
       name  = "armonik-worker"
       image = "dockerhubaneo/armonik_worker_dll"
-      tag   = "0.9.2"
+      tag   = "0.9.4"
     },
     {
       name  = "metrics-exporter"

--- a/infrastructure/quick-deploy/aws/ecr/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/ecr/parameters.tfvars
@@ -48,12 +48,12 @@ ecr = {
     {
       name  = "armonik-control-plane"
       image = "dockerhubaneo/armonik_control"
-      tag   = "0.12.2"
+      tag   = "0.12.3"
     },
     {
       name  = "armonik-polling-agent"
       image = "dockerhubaneo/armonik_pollingagent"
-      tag   = "0.12.2"
+      tag   = "0.12.3"
     },
     {
       name  = "armonik-worker"
@@ -63,12 +63,12 @@ ecr = {
     {
       name  = "metrics-exporter"
       image = "dockerhubaneo/armonik_control_metrics"
-      tag   = "0.12.2"
+      tag   = "0.12.3"
     },
     {
       name  = "partition-metrics-exporter"
       image = "dockerhubaneo/armonik_control_partition_metrics"
-      tag   = "0.12.2"
+      tag   = "0.12.3"
     },
     {
       name  = "armonik-admin-app"

--- a/infrastructure/quick-deploy/aws/monitoring/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/monitoring/parameters.tfvars
@@ -78,7 +78,7 @@ monitoring = {
   }
   metrics_exporter = {
     image              = "125796369274.dkr.ecr.eu-west-3.amazonaws.com/metrics-exporter"
-    tag                = "0.12.2"
+    tag                = "0.12.3"
     image_pull_secrets = ""
     service_type       = "ClusterIP"
     node_selector      = { "grid/type" = "Operator" }
@@ -91,7 +91,7 @@ monitoring = {
   }
   partition_metrics_exporter = {
     image              = "125796369274.dkr.ecr.eu-west-3.amazonaws.com/partition-metrics-exporter"
-    tag                = "0.12.2"
+    tag                = "0.12.3"
     image_pull_secrets = ""
     service_type       = "ClusterIP"
     node_selector      = { "grid/type" = "Operator" }

--- a/infrastructure/quick-deploy/localhost/armonik/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/armonik/parameters.tfvars
@@ -157,7 +157,7 @@ compute_plane = {
       {
         name              = "worker"
         image             = "dockerhubaneo/armonik_worker_dll"
-        tag               = "0.9.2"
+        tag               = "0.9.4"
         image_pull_policy = "IfNotPresent"
         limits = {
           cpu    = "1000m"  # set to null if you don't want to set it

--- a/infrastructure/quick-deploy/localhost/armonik/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/armonik/parameters.tfvars
@@ -21,7 +21,7 @@ control_plane = {
   service_type      = "ClusterIP"
   replicas          = 1
   image             = "dockerhubaneo/armonik_control"
-  tag               = "0.12.2"
+  tag               = "0.12.3"
   image_pull_policy = "IfNotPresent"
   port              = 5001
   limits = {
@@ -141,7 +141,7 @@ compute_plane = {
     # ArmoniK polling agent
     polling_agent = {
       image             = "dockerhubaneo/armonik_pollingagent"
-      tag               = "0.12.2"
+      tag               = "0.12.3"
       image_pull_policy = "IfNotPresent"
       limits = {
         cpu    = "2000m"  # set to null if you don't want to set it

--- a/infrastructure/quick-deploy/localhost/monitoring/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/monitoring/parameters.tfvars
@@ -38,7 +38,7 @@ monitoring = {
   }
   metrics_exporter = {
     image              = "dockerhubaneo/armonik_control_metrics"
-    tag                = "0.12.2"
+    tag                = "0.12.3"
     image_pull_secrets = ""
     service_type       = "ClusterIP"
     node_selector      = {}
@@ -51,7 +51,7 @@ monitoring = {
   }
   partition_metrics_exporter = {
     image              = "dockerhubaneo/armonik_control_partition_metrics"
-    tag                = "0.12.2"
+    tag                = "0.12.3"
     image_pull_secrets = ""
     service_type       = "ClusterIP"
     node_selector      = {}

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -4,7 +4,7 @@
     "core":      "0.12.3",
     "api":       "3.6.0",
     "gui":       "0.9.0",
-    "extcsharp": "0.9.2",
+    "extcsharp": "0.9.4",
     "samples":   "2.12.0"
   },
   "armonik_images": {

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,7 +1,7 @@
 {
   "armonik_versions": {
     "infra":     "2.12.0",
-    "core":      "0.12.2",
+    "core":      "0.12.3",
     "api":       "3.6.0",
     "gui":       "0.9.0",
     "extcsharp": "0.9.2",


### PR DESCRIPTION
## [v2.12.1](https://github.com/aneoconsulting/armonik/tree/v2.12.0) (2023-04-06)
Changed
-

* Upgrade versions of docker images for ArmoniK (see [versions.tfvars.json](./versions.tfvars.json)):
  * Core version from `0.12.2` to `0.12.3`.
  * Extension C# version from `0.9.2` to `0.9.4`.
* Samples version from `v2.12.0` to `v2.12.1`

Fixed
- 

* Fix issue with AWSSDK.SecurityToken [#145](https://github.com/aneoconsulting/ArmoniK.Extensions.Csharp/pull/145)
