### PR TITLE
feat: add minio as zip storage for localhost deployment

### DIFF
--- a/infrastructure/modules/armonik/locals.tf
+++ b/infrastructure/modules/armonik/locals.tf
@@ -77,6 +77,7 @@ locals {
     S3Storage__AccessKeyId     = data.kubernetes_secret.shared_storage.data.access_key_id
     S3Storage__SecretAccessKey = data.kubernetes_secret.shared_storage.data.secret_access_key
     S3Storage__BucketName      = data.kubernetes_secret.shared_storage.data.name
+    S3Storage__MustForcePathStyle = data.kubernetes_secret.shared_storage.data.must_force_path_style    
   } : {}
 
   # Object storage

--- a/infrastructure/modules/armonik/locals.tf
+++ b/infrastructure/modules/armonik/locals.tf
@@ -73,11 +73,11 @@ locals {
   file_storage_type       = lower(data.kubernetes_secret.shared_storage.data.file_storage_type)
   check_file_storage_type = local.file_storage_type == "s3" ? "S3" : "FS"
   file_storage_endpoints = local.check_file_storage_type == "S3" ? {
-    S3Storage__ServiceURL      = data.kubernetes_secret.shared_storage.data.service_url
-    S3Storage__AccessKeyId     = data.kubernetes_secret.shared_storage.data.access_key_id
-    S3Storage__SecretAccessKey = data.kubernetes_secret.shared_storage.data.secret_access_key
-    S3Storage__BucketName      = data.kubernetes_secret.shared_storage.data.name
-    S3Storage__MustForcePathStyle = data.kubernetes_secret.shared_storage.data.must_force_path_style    
+    S3Storage__ServiceURL         = data.kubernetes_secret.shared_storage.data.service_url
+    S3Storage__AccessKeyId        = data.kubernetes_secret.shared_storage.data.access_key_id
+    S3Storage__SecretAccessKey    = data.kubernetes_secret.shared_storage.data.secret_access_key
+    S3Storage__BucketName         = data.kubernetes_secret.shared_storage.data.name
+    S3Storage__MustForcePathStyle = data.kubernetes_secret.shared_storage.data.must_force_path_style
   } : {}
 
   # Object storage

--- a/infrastructure/modules/onpremise-storage/minio/locals.tf
+++ b/infrastructure/modules/onpremise-storage/minio/locals.tf
@@ -2,4 +2,5 @@ locals {
   node_selector_keys   = keys(var.minio.node_selector)
   node_selector_values = values(var.minio.node_selector)
   port                 = 9000
+  console_port         = 9001
 }

--- a/infrastructure/modules/onpremise-storage/minio/minio.tf
+++ b/infrastructure/modules/onpremise-storage/minio/minio.tf
@@ -1,12 +1,12 @@
 # Kubernetes minio deployment
 resource "kubernetes_deployment" "minio" {
   metadata {
-    name      = "minio"
+    name      = var.minio.host
     namespace = var.namespace
     labels = {
       app     = "storage"
       type    = "object"
-      service = "minio"
+      service = var.minio.host
     }
   }
   spec {
@@ -15,16 +15,16 @@ resource "kubernetes_deployment" "minio" {
       match_labels = {
         app     = "storage"
         type    = "object"
-        service = "minio"
+        service = var.minio.host
       }
     }
     template {
       metadata {
-        name = "minio"
+        name = var.minio.host
         labels = {
           app     = "storage"
           type    = "object"
-          service = "minio"
+          service = var.minio.host
         }
       }
       spec {

--- a/infrastructure/modules/onpremise-storage/minio/minio.tf
+++ b/infrastructure/modules/onpremise-storage/minio/minio.tf
@@ -56,7 +56,7 @@ resource "kubernetes_deployment" "minio" {
           command           = ["/bin/bash"]
           args = [
             "-c",
-            "mkdir -p /data/${var.minio.bucket_name} && minio server /data --console-address :9001"
+            "mkdir -p /data/${var.minio.bucket_name} && minio server /data --console-address :${local.console_port}"
           ]
           env {
             name  = "MINIO_ROOT_USER"
@@ -71,7 +71,7 @@ resource "kubernetes_deployment" "minio" {
             protocol       = "TCP"
           }
           port {
-            container_port = 9001
+            container_port = local.console_port
             protocol       = "TCP"
           }
         }
@@ -105,9 +105,9 @@ resource "kubernetes_service" "minio" {
       protocol    = "TCP"
     }
     port {
-      name        = "${kubernetes_deployment.minio.metadata.0.name}-9001"
-      port        = 9001
-      target_port = 9001
+      name        = "${kubernetes_deployment.minio.metadata.0.name}-${local.console_port}"
+      port        = local.console_port
+      target_port = local.console_port
       protocol    = "TCP"
     }
   }

--- a/infrastructure/modules/onpremise-storage/minio/outputs.tf
+++ b/infrastructure/modules/onpremise-storage/minio/outputs.tf
@@ -10,6 +10,10 @@ output "url" {
   value = "http://${var.minio.host}:${local.port}"
 }
 
+output "console_url" {
+  value = "http://${var.minio.host}:${local.console_port}"
+}
+
 output "login" {
   value     = random_string.minio_application_user.result
   sensitive = true

--- a/infrastructure/quick-deploy/localhost/all/common.tf
+++ b/infrastructure/quick-deploy/localhost/all/common.tf
@@ -19,12 +19,13 @@ locals {
   # Minio file storage
   minio_s3_fs_image              = try(var.minio_s3_fs.image, "minio/minio")
   minio_s3_fs_image_pull_secrets = try(var.minio_s3_fs.image_pull_secrets, "")
-  minio_s3_fs_host               = try(var.minio_s3_fs.host, "minio")
+  minio_s3_fs_host               = try(var.minio_s3_fs.host, "minio_s3_fs")
   minio_s3_fs_bucket_name        = try(var.minio_s3_fs.default_bucket, "minioBucket")
   minio_s3_fs_node_selector      = try(var.minio_s3_fs.node_selector, {})
   shared_storage_minio_s3_fs = var.minio_s3_fs != null ? {
     file_storage_type     = "s3"
     service_url           = module.minio_s3_fs[0].url
+    console_url           = module.minio_s3_fs[0].console_url
     access_key_id         = module.minio_s3_fs[0].login
     secret_access_key     = module.minio_s3_fs[0].password
     name                  = module.minio_s3_fs[0].bucket_name

--- a/infrastructure/quick-deploy/localhost/all/common.tf
+++ b/infrastructure/quick-deploy/localhost/all/common.tf
@@ -14,4 +14,26 @@ resource "kubernetes_namespace" "armonik" {
 locals {
   prefix    = try(coalesce(var.prefix), "armonik-${random_string.prefix.result}")
   namespace = kubernetes_namespace.armonik.metadata[0].name
+
+
+  # Minio file storage
+  minio_s3_fs_image              = try(var.minio_s3_fs.image, "minio/minio")
+  minio_s3_fs_image_pull_secrets = try(var.minio_s3_fs.image_pull_secrets, "")
+  minio_s3_fs_host               = try(var.minio_s3_fs.host, "minio")
+  minio_s3_fs_bucket_name        = try(var.minio_s3_fs.default_bucket, "minioBucket")
+  minio_s3_fs_node_selector      = try(var.minio_s3_fs.node_selector, {})
+  shared_storage_minio_s3_fs = var.minio_s3_fs != null ? {
+    file_storage_type     = "s3"
+    service_url           = module.minio_s3_fs[0].url
+    access_key_id         = module.minio_s3_fs[0].login
+    secret_access_key     = module.minio_s3_fs[0].password
+    name                  = module.minio_s3_fs[0].bucket_name
+    must_force_path_style = module.minio_s3_fs[0].must_force_path_style
+  } : {}
+  shared_storage_localhost_default = {
+    host_path         = abspath("data")
+    file_storage_type = "HostPath"
+    file_server_ip    = ""
+  }
+  shared_storage = var.minio_s3_fs != null ? local.shared_storage_minio_s3_fs : local.shared_storage_localhost_default
 }

--- a/infrastructure/quick-deploy/localhost/all/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/all/parameters.tfvars
@@ -8,6 +8,7 @@ logging_level = "Information"
 # Uncomment either the `redis` or the `minio` parameter
 redis = {}
 #minio = {}
+#minio_s3_fs = {}
 
 metrics_exporter = {
   extra_conf = {

--- a/infrastructure/quick-deploy/localhost/all/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/all/parameters.tfvars
@@ -8,7 +8,9 @@ logging_level = "Information"
 # Uncomment either the `redis` or the `minio` parameter
 redis = {}
 #minio = {}
-#minio_s3_fs = {}
+
+# Uncomment this to have minio S3 enabled instead of hostpath shared_storage
+#minio_s3_fs = {} # Shared storage
 
 metrics_exporter = {
   extra_conf = {

--- a/infrastructure/quick-deploy/localhost/all/providers.tf
+++ b/infrastructure/quick-deploy/localhost/all/providers.tf
@@ -1,6 +1,6 @@
 # K8s configuration
 data "external" "k8s_config_context" {
-  program     = ["bash", "k8s_config.sh"]
+  program     = ["bash", "k8s_config.sh", var.k8s_config_path]
   working_dir = ".${path.root}/../../utils/scripts"
 }
 

--- a/infrastructure/quick-deploy/localhost/all/storage.tf
+++ b/infrastructure/quick-deploy/localhost/all/storage.tf
@@ -56,17 +56,28 @@ module "minio" {
   }
 }
 
+# minio for file storage
+module "minio_s3_fs" {
+  count     = var.minio_s3_fs != null ? 1 : 0
+  source    = "../../../modules/onpremise-storage/minio"
+  namespace = local.namespace
+  minio = {
+    image              = local.minio_s3_fs_image
+    tag                = try(coalesce(var.minio.image_tag), local.default_tags[var.minio_s3_fs.image_name])
+    image_pull_secrets = local.minio_s3_fs_image_pull_secrets
+    host               = local.minio_s3_fs_host
+    bucket_name        = local.minio_s3_fs_bucket_name
+    node_selector      = local.minio_s3_fs_node_selector
+  }
+}
+
 # Shared storage
 resource "kubernetes_secret" "shared_storage" {
   metadata {
     name      = "shared-storage"
     namespace = local.namespace
   }
-  data = {
-    host_path         = abspath("data")
-    file_storage_type = "HostPath"
-    file_server_ip    = ""
-  }
+  data = local.shared_storage
 }
 
 resource "kubernetes_secret" "deployed_object_storage" {

--- a/infrastructure/quick-deploy/localhost/all/variables.tf
+++ b/infrastructure/quick-deploy/localhost/all/variables.tf
@@ -47,6 +47,7 @@ variable "metrics_server" {
       "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
       "--kubelet-use-node-status-port",
       "--metric-resolution=15s",
+      "--kubelet-insecure-tls"
     ]),
     host_network          = optional(bool, false),
     helm_chart_repository = optional(string, "https://kubernetes-sigs.github.io/metrics-server/")

--- a/infrastructure/quick-deploy/localhost/all/variables.tf
+++ b/infrastructure/quick-deploy/localhost/all/variables.tf
@@ -137,6 +137,20 @@ variable "minio" {
   default = null
 }
 
+# Parameters for Minio file storage
+variable "minio_s3_fs" {
+  description = "Parameters of Minio"
+  type = object({
+    image_name         = optional(string, "minio/minio")
+    image_tag          = optional(string)
+    node_selector      = optional(any, {})
+    image_pull_secrets = optional(string, "")
+    default_bucket     = optional(string, "minioBucket")
+    host               = optional(string, "minio-s3-fs")
+  })
+  default = null
+}
+
 variable "seq" {
   description = "Seq configuration"
   type = object({

--- a/infrastructure/quick-deploy/localhost/armonik/providers.tf
+++ b/infrastructure/quick-deploy/localhost/armonik/providers.tf
@@ -1,6 +1,6 @@
 # K8s configuration
 data "external" "k8s_config_context" {
-  program     = ["bash", "k8s_config.sh"]
+  program     = ["bash", "k8s_config.sh", var.k8s_config_path]
   working_dir = ".${path.root}/../../utils/scripts"
 }
 

--- a/infrastructure/quick-deploy/localhost/keda/providers.tf
+++ b/infrastructure/quick-deploy/localhost/keda/providers.tf
@@ -1,6 +1,6 @@
 # K8s configuration
 data "external" "k8s_config_context" {
-  program     = ["bash", "k8s_config.sh"]
+  program     = ["bash", "k8s_config.sh", var.k8s_config_path]
   working_dir = ".${path.root}/../../utils/scripts"
 }
 

--- a/infrastructure/quick-deploy/localhost/metrics-server/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/metrics-server/parameters.tfvars
@@ -18,7 +18,8 @@ args = [
   "--cert-dir=/tmp",
   "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
   "--kubelet-use-node-status-port",
-  "--metric-resolution=15s"
+  "--metric-resolution=15s",
+  "--kubelet-insecure-tls"
 ]
 
 # Host network

--- a/infrastructure/quick-deploy/localhost/metrics-server/providers.tf
+++ b/infrastructure/quick-deploy/localhost/metrics-server/providers.tf
@@ -1,6 +1,6 @@
 # K8s configuration
 data "external" "k8s_config_context" {
-  program     = ["bash", "k8s_config.sh"]
+  program     = ["bash", "k8s_config.sh", var.k8s_config_path]
   working_dir = ".${path.root}/../../utils/scripts"
 }
 

--- a/infrastructure/quick-deploy/localhost/monitoring/providers.tf
+++ b/infrastructure/quick-deploy/localhost/monitoring/providers.tf
@@ -1,6 +1,6 @@
 # K8s configuration
 data "external" "k8s_config_context" {
-  program     = ["bash", "k8s_config.sh"]
+  program     = ["bash", "k8s_config.sh", var.k8s_config_path]
   working_dir = ".${path.root}/../../utils/scripts"
 }
 

--- a/infrastructure/quick-deploy/localhost/storage/locals.tf
+++ b/infrastructure/quick-deploy/localhost/storage/locals.tf
@@ -27,7 +27,7 @@ locals {
   minio_bucket_name        = try(var.minio.default_bucket, "minioBucket")
   minio_node_selector      = try(var.minio.node_selector, {})
 
-# Minio for file storage
+  # Minio for file storage
   minio_s3_fs_image              = try(var.minio_s3_fs.image, "minio/minio")
   minio_s3_fs_tag                = try(var.minio_s3_fs.tag, "RELEASE.2023-01-25T00-19-54Z")
   minio_s3_fs_image_pull_secrets = try(var.minio_s3_fs.image_pull_secrets, "")
@@ -35,19 +35,19 @@ locals {
   minio_s3_fs_bucket_name        = try(var.minio_s3_fs.default_bucket, "minioBucket")
   minio_s3_fs_node_selector      = try(var.minio_s3_fs.node_selector, {})
   shared_storage_minio_s3_fs = var.minio_s3_fs != null ? {
-    file_storage_type = "s3"
-    service_url      = module.minio_s3_fs[0].url
-    access_key_id     = module.minio_s3_fs[0].login
-    secret_access_key = module.minio_s3_fs[0].password
-    name      = module.minio_s3_fs[0].bucket_name
+    file_storage_type     = "s3"
+    service_url           = module.minio_s3_fs[0].url
+    access_key_id         = module.minio_s3_fs[0].login
+    secret_access_key     = module.minio_s3_fs[0].password
+    name                  = module.minio_s3_fs[0].bucket_name
     must_force_path_style = module.minio_s3_fs[0].must_force_path_style
-} : {}
-shared_storage_localhost_default = {
-      host_path         = try(var.shared_storage.host_path, "/data")
-      file_storage_type = try(var.shared_storage.file_storage_type, "HostPath")
-      file_server_ip    = try(var.shared_storage.file_server_ip, "")
-}
-shared_storage = var.minio_s3_fs != null ? local.shared_storage_minio_s3_fs : local.shared_storage_localhost_default
+  } : {}
+  shared_storage_localhost_default = {
+    host_path         = try(var.shared_storage.host_path, "/data")
+    file_storage_type = try(var.shared_storage.file_storage_type, "HostPath")
+    file_server_ip    = try(var.shared_storage.file_server_ip, "")
+  }
+  shared_storage = var.minio_s3_fs != null ? local.shared_storage_minio_s3_fs : local.shared_storage_localhost_default
 
 
 

--- a/infrastructure/quick-deploy/localhost/storage/locals.tf
+++ b/infrastructure/quick-deploy/localhost/storage/locals.tf
@@ -31,12 +31,14 @@ locals {
   minio_s3_fs_image              = try(var.minio_s3_fs.image, "minio/minio")
   minio_s3_fs_tag                = try(var.minio_s3_fs.tag, "RELEASE.2023-01-25T00-19-54Z")
   minio_s3_fs_image_pull_secrets = try(var.minio_s3_fs.image_pull_secrets, "")
-  minio_s3_fs_host               = try(var.minio_s3_fs.host, "minio")
+  minio_s3_fs_host               = try(var.minio_s3_fs.host, "minio_s3_fs")
   minio_s3_fs_bucket_name        = try(var.minio_s3_fs.default_bucket, "minioBucket")
   minio_s3_fs_node_selector      = try(var.minio_s3_fs.node_selector, {})
   shared_storage_minio_s3_fs = var.minio_s3_fs != null ? {
     file_storage_type     = "s3"
+    host                  = module.minio_s3_fs[0].host
     service_url           = module.minio_s3_fs[0].url
+    console_url           = module.minio_s3_fs[0].console_url
     access_key_id         = module.minio_s3_fs[0].login
     secret_access_key     = module.minio_s3_fs[0].password
     name                  = module.minio_s3_fs[0].bucket_name

--- a/infrastructure/quick-deploy/localhost/storage/locals.tf
+++ b/infrastructure/quick-deploy/localhost/storage/locals.tf
@@ -27,10 +27,29 @@ locals {
   minio_bucket_name        = try(var.minio.default_bucket, "minioBucket")
   minio_node_selector      = try(var.minio.node_selector, {})
 
-  # Shared storage
-  shared_storage_host_path         = try(var.shared_storage.host_path, "/data")
-  shared_storage_file_storage_type = try(var.shared_storage.file_storage_type, "HostPath")
-  shared_storage_file_server_ip    = try(var.shared_storage.file_server_ip, "")
+# Minio for file storage
+  minio_s3_fs_image              = try(var.minio_s3_fs.image, "minio/minio")
+  minio_s3_fs_tag                = try(var.minio_s3_fs.tag, "RELEASE.2023-01-25T00-19-54Z")
+  minio_s3_fs_image_pull_secrets = try(var.minio_s3_fs.image_pull_secrets, "")
+  minio_s3_fs_host               = try(var.minio_s3_fs.host, "minio")
+  minio_s3_fs_bucket_name        = try(var.minio_s3_fs.default_bucket, "minioBucket")
+  minio_s3_fs_node_selector      = try(var.minio_s3_fs.node_selector, {})
+  shared_storage_minio_s3_fs = var.minio_s3_fs != null ? {
+    file_storage_type = "s3"
+    service_url      = module.minio_s3_fs[0].url
+    access_key_id     = module.minio_s3_fs[0].login
+    secret_access_key = module.minio_s3_fs[0].password
+    name      = module.minio_s3_fs[0].bucket_name
+    must_force_path_style = module.minio_s3_fs[0].must_force_path_style
+} : {}
+shared_storage_localhost_default = {
+      host_path         = try(var.shared_storage.host_path, "/data")
+      file_storage_type = try(var.shared_storage.file_storage_type, "HostPath")
+      file_server_ip    = try(var.shared_storage.file_server_ip, "")
+}
+shared_storage = var.minio_s3_fs != null ? local.shared_storage_minio_s3_fs : local.shared_storage_localhost_default
+
+
 
   # Deployed storage
   deployed_object_storages = concat(

--- a/infrastructure/quick-deploy/localhost/storage/main.tf
+++ b/infrastructure/quick-deploy/localhost/storage/main.tf
@@ -55,3 +55,19 @@ module "minio" {
     node_selector      = local.minio_node_selector
   }
 }
+
+
+# minio for file storage
+module "minio_s3_fs" {
+  count     = var.minio_s3_fs != null ? 1 : 0
+  source    = "../../../modules/onpremise-storage/minio"
+  namespace = var.namespace
+  minio = {
+    image              = local.minio_s3_fs_image
+    tag                = local.minio_s3_fs_tag
+    image_pull_secrets = local.minio_s3_fs_image_pull_secrets
+    host               = local.minio_s3_fs_host
+    bucket_name        = local.minio_s3_fs_bucket_name
+    node_selector      = local.minio_s3_fs_node_selector
+  }
+}

--- a/infrastructure/quick-deploy/localhost/storage/outputs.tf
+++ b/infrastructure/quick-deploy/localhost/storage/outputs.tf
@@ -25,6 +25,5 @@ output "storage_endpoint_url" {
       url                = module.mongodb.url
       number_of_replicas = var.mongodb.replicas_number
     }
-    shared = local.shared_storage
   }
 }

--- a/infrastructure/quick-deploy/localhost/storage/outputs.tf
+++ b/infrastructure/quick-deploy/localhost/storage/outputs.tf
@@ -25,10 +25,6 @@ output "storage_endpoint_url" {
       url                = module.mongodb.url
       number_of_replicas = var.mongodb.replicas_number
     }
-    shared = {
-      host_path         = local.shared_storage_host_path
-      file_storage_type = local.shared_storage_file_storage_type
-      file_server_ip    = local.shared_storage_file_server_ip
-    }
+    shared = local.shared_storage
   }
 }

--- a/infrastructure/quick-deploy/localhost/storage/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/storage/parameters.tfvars
@@ -1,6 +1,8 @@
 # Kubernetes namespace
 namespace = "armonik"
 
+#minio_s3_fs = {}
+
 # Shared storage
 shared_storage = {
   host_path         = "/data"

--- a/infrastructure/quick-deploy/localhost/storage/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/storage/parameters.tfvars
@@ -1,6 +1,8 @@
 # Kubernetes namespace
 namespace = "armonik"
 
+
+# Uncomment this to have minio S3 enabled instead of hostpath shared_storage
 #minio_s3_fs = {}
 
 # Shared storage

--- a/infrastructure/quick-deploy/localhost/storage/providers.tf
+++ b/infrastructure/quick-deploy/localhost/storage/providers.tf
@@ -1,6 +1,6 @@
 # K8s configuration
 data "external" "k8s_config_context" {
-  program     = ["bash", "k8s_config.sh"]
+  program     = ["bash", "k8s_config.sh", var.k8s_config_path]
   working_dir = ".${path.root}/../../utils/scripts"
 }
 

--- a/infrastructure/quick-deploy/localhost/storage/secrets.tf
+++ b/infrastructure/quick-deploy/localhost/storage/secrets.tf
@@ -3,11 +3,7 @@ resource "kubernetes_secret" "shared_storage" {
     name      = "shared-storage"
     namespace = var.namespace
   }
-  data = {
-    host_path         = local.shared_storage_host_path
-    file_storage_type = local.shared_storage_file_storage_type
-    file_server_ip    = local.shared_storage_file_server_ip
-  }
+  data = local.shared_storage
 }
 
 resource "kubernetes_secret" "deployed_object_storage" {

--- a/infrastructure/quick-deploy/localhost/storage/variables.tf
+++ b/infrastructure/quick-deploy/localhost/storage/variables.tf
@@ -78,3 +78,17 @@ variable "minio" {
   })
   default = null
 }
+
+# Parameters for minio file storage
+variable "minio_s3_fs" {
+  description = "Parameters of Minio"
+  type = object({
+    image_name         = optional(string, "minio/minio")
+    image_tag          = optional(string)
+    node_selector      = optional(any, {})
+    image_pull_secrets = optional(string, "")
+    default_bucket     = optional(string, "minioBucket")
+    host               = optional(string, "minio-s3-fs")
+  })
+  default = null
+}

--- a/infrastructure/utils/scripts/k8s_config.sh
+++ b/infrastructure/utils/scripts/k8s_config.sh
@@ -2,34 +2,7 @@
 # Exit if any of the intermediate steps fail
 set -e
 
-
-echo "tilde :" > ./debug.txt
-echo ~/ >> ./debug.txt
-echo "dollar 1 :" >> ./debug.txt
-echo "$1" >> ./debug.txt
-
-export kubefilelocation=~/.kube
-echo "display home : " >> ./debug.txt
-ls -ail /home/ >> ./debug.txt
-echo "display home runner : " >> ./debug.txt
-ls -ail /home/runner >> ./debug.txt
-
-echo "kubefile location : " >> ./debug.txt
-ls -ail "$kubefilelocation" >> ./debug.txt
-echo "Kubecl config view : " >> ./debug.txt
-kubectl --kubeconfig "$1" config view  >> ./debug.txt
-
-echo "Kubecl --kubeconfig "$1" config view : " >> ./debug.txt
-kubectl --kubeconfig "$1" config view  >> ./debug.txt
-
-echo "Kubecl config view : " >> ./debug.txt
-kubectl config view  >> ./debug.txt
-
-echo "ENV : " >> ./debug.txt
-env >> ./debug.txt
-
-cat ./debug.txt >/dev/stderr
-
-CONFIG_CONTEXT=$(kubectl --kubeconfig "$1" config current-context)
+eval kubefilelocation=$1 # ~ expand does not work in terraform so we expend it manually
+CONFIG_CONTEXT=$(kubectl --kubeconfig "$kubefilelocation" config current-context)
 
 jq -n --arg k8s_config_context "$CONFIG_CONTEXT" '{"k8s_config_context":$k8s_config_context}'

--- a/infrastructure/utils/scripts/k8s_config.sh
+++ b/infrastructure/utils/scripts/k8s_config.sh
@@ -2,6 +2,34 @@
 # Exit if any of the intermediate steps fail
 set -e
 
+
+echo "tilde :" > ./debug.txt
+echo ~/ >> ./debug.txt
+echo "dollar 1 :" >> ./debug.txt
+echo "$1" >> ./debug.txt
+
+export kubefilelocation=~/.kube
+echo "display home : " >> ./debug.txt
+ls -ail /home/ >> ./debug.txt
+echo "display home runner : " >> ./debug.txt
+ls -ail /home/runner >> ./debug.txt
+
+echo "kubefile location : " >> ./debug.txt
+ls -ail "$kubefilelocation" >> ./debug.txt
+echo "Kubecl config view : " >> ./debug.txt
+kubectl --kubeconfig "$1" config view  >> ./debug.txt
+
+echo "Kubecl --kubeconfig "$1" config view : " >> ./debug.txt
+kubectl --kubeconfig "$1" config view  >> ./debug.txt
+
+echo "Kubecl config view : " >> ./debug.txt
+kubectl config view  >> ./debug.txt
+
+echo "ENV : " >> ./debug.txt
+env >> ./debug.txt
+
+cat ./debug.txt >/dev/stderr
+
 CONFIG_CONTEXT=$(kubectl --kubeconfig "$1" config current-context)
 
 jq -n --arg k8s_config_context "$CONFIG_CONTEXT" '{"k8s_config_context":$k8s_config_context}'


### PR DESCRIPTION
related issue : [link](https://github.com/aneoconsulting/ArmoniK/issues/1040)
rem nginx config for minio http://ip.of.the.loadbalancer/minio seems impossible : https://min.io/docs/minio/linux/integrations/setup-nginx-proxy-with-minio.html

"_The S3 API signature calculation algorithm does not support proxy schemes where you host either the MinIO Server API or Console GUI on a subpath, such as example.net/s3/ or example.net/console/._"
