### PR TITLE
chore: allow renovate to group pr by datasources

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base",
-              "group:allNonMajor",
-              ":semanticCommits"
-             ],
-  "packageRules":
-  [
+  "extends": [
+    "config:base",
+    "group:allNonMajor",
+    ":semanticCommitTypeAll(chore)",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "rangeStrategy": "bump",
+  "npm": {
+    "commitMessageTopic": "{{prettyDepType}} {{depName}}"
+  },
+  "packageRules": [
     {
-      "matchPackagePrefixes": ["ArmoniK"],
-      "groupName": "release packages Armonik"
+      "groupName": "npm packages",
+      "groupSlug": "npm",
+      "matchDatasources": [
+        "npm"
+      ]
     },
     {
-
-    "matchPackagePatterns": ["*"],
-    "excludePackagePrefixes": ["ArmoniK"],
-    "groupName": "other dependencies"  
-    }
+      "groupName": "terraform modules",
+      "groupSlug": "terraform-module",
+      "matchDatasources": [
+        "terraform-module"
+      ]
+    },
+    {
+      "groupName": "terraform provides",
+      "groupSlug": "terraform-provider",
+      "matchDatasources": [
+        "terraform-provider"
+      ]
+    },
+    {
+      "groupName": "github actions",
+      "groupSlug": "github-actions",
+      "matchDatasources": [
+        "github-tags"
+      ]
+    },
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,9 +7,6 @@
     "helpers:pinGitHubActionDigests"
   ],
   "rangeStrategy": "bump",
-  "npm": {
-    "commitMessageTopic": "{{prettyDepType}} {{depName}}"
-  },
   "packageRules": [
     {
       "groupName": "npm packages",


### PR DESCRIPTION
This PR group renovate's PR by [datasources](https://docs.renovatebot.com/modules/datasource/).

```json
{
  "matchPackagePrefixes": ["ArmoniK"],
  "groupName": "release packages Armonik"
},
```

⬆️ is not needed because there is no ArmoniK package in this repo.

For security reasons, I added "helpers:pinGitHubActionDigests" in order to pin actions to a specific version.

To view an example: https://github.com/esoubiran-aneo/ArmoniK