### PR TITLE
docs: fix links

### DIFF
--- a/.docs/content/1.installation/1.linux/2.all-in-one-deployment.md
+++ b/.docs/content/1.installation/1.linux/2.all-in-one-deployment.md
@@ -8,17 +8,13 @@ This deployment is for development purposes.
 
 ## Deploy
 
-To launch the deployment, go to the [`infrastructure/quick-deploy/localhost/all`](https://github.com/aneoconsulting/ArmoniK/tree/main/infrastructure/quick-deploy/localhost/all) directory:
+To launch the deployment, go to the `infrastructure/quick-deploy/localhost/all` directory:
 
-If you want to deploy on AWS, go to the dedicated section on [`AWS`](https://github.com/aneoconsulting/ArmoniK/tree/main/infrastructure/quick-deploy/aws/all)
+::alert={type="info"}
+If you want to deploy on AWS, go to the dedicated section on [`AWS`](/installation/aws/aws-all-in-one-deployment)
+::
 
 Execute the following command:
-
-```bash
-make
-```
-
-or
 
 ```bash
 make deploy
@@ -26,16 +22,16 @@ make deploy
 
 ## Configuration
 
-All parameters are contained in [`parameters.tfvars`](https://github.com/aneoconsulting/ArmoniK/blob/main/infrastructure/quick-deploy/localhost/all/parameters.tfvars)
+All parameters are contained in `parameters.tfvars` in `infrastructure/quick-deploy/localhost/all`.
 
 ::alert{type="info"}
-By default, all the cloud services are set to launch. To see what kind of parameters are available, read [`variables.tf`](https://github.com/aneoconsulting/ArmoniK/blob/main/infrastructure/quick-deploy/localhost/all/variables.tf)
+By default, all the cloud services are set to launch. To see what kind of parameters are available, read `variables.tf` in `infrastructure/quick-deploy/localhost/all` to discover them.
 ::
 
-You can specify a custom parameter file. When executing the `make` command, you may use the `PARAMETERS_FILE` option to set the path to your file.
+You can specify a custom parameter file. When executing the `make deploy` command, you may use the `PARAMETERS_FILE` option to set the path to your file.
 
 ```bash
-make PARAMETERS_FILE=my-custom-parameters.tfvars
+make deploy PARAMETERS_FILE=my-custom-parameters.tfvars
 ```
 
 ## Destroy


### PR DESCRIPTION
fix links in the localhost all in one.

I also remove the `make` command since this command do exactly the same as `make deploy`. And because we have `make destroy`, having `make deploy` make more sens.