### PR TITLE
feat: expose max_memory_samples parameter for redis/elasticache

### DIFF
--- a/infrastructure/quick-deploy/aws/storage.tf
+++ b/infrastructure/quick-deploy/aws/storage.tf
@@ -98,6 +98,7 @@ module "elasticache" {
   preferred_cache_cluster_azs = var.elasticache.preferred_cache_cluster_azs
   data_tiering_enabled        = var.elasticache.data_tiering_enabled
   log_retention_in_days       = var.elasticache.log_retention_in_days
+  max_memory_samples          = var.elasticache.max_memory_samples
 
   kms_key_id     = local.kms_key
   log_kms_key_id = local.kms_key

--- a/infrastructure/quick-deploy/aws/variables.tf
+++ b/infrastructure/quick-deploy/aws/variables.tf
@@ -254,6 +254,7 @@ variable "elasticache" {
     preferred_cache_cluster_azs = optional(list(string), [])
     data_tiering_enabled        = optional(bool, false)
     log_retention_in_days       = optional(number, 30)
+    max_memory_samples          = optional(number)
     cloudwatch_log_groups = optional(object({
       slow_log   = optional(string, "")
       engine_log = optional(string, "")


### PR DESCRIPTION
linked to infra pr : [link](https://github.com/aneoconsulting/ArmoniK.Infra/pull/105)

As described in the official Redis documentation :
Redis LRU eviction is not a perfect LRU but use sampling : [link](https://redis.io/docs/reference/eviction/#approximated-lru-algorithm)
=> during the eviction process by default batchs of 5 random keys are challenged and the oldest one is removed
=> This can lead to data loss in our running job.
Depending of the user workload it can be helpful to expose the sampling number in the configuration of redis/elasticache
It will not fix the problem, but it will reduce the frequency of its occurrence.
test validation screenshot on AWS
