### PR TITLE
fix: generated prefix length 10 -> 5 for gke service account

### DIFF
--- a/infrastructure/quick-deploy/gcp/all-in-one/Makefile
+++ b/infrastructure/quick-deploy/gcp/all-in-one/Makefile
@@ -11,7 +11,7 @@ MODULES_SOURCE=$(shell cat $(VERSIONS_FILE) | jq -r '.armonik_images.infra[0]')
 MODULES_VERSION=$(shell cat $(VERSIONS_FILE) | jq -r '.armonik_versions.infra')
 
 # Randomly generated string that is preserved across calls
-RANDOM_PREFIX != [ -e $(GENERATED_DIR)/.prefix ] || { mkdir -p $(GENERATED_DIR) && tr -dc a-z0-9 </dev/urandom | head -c 10 > $(GENERATED_DIR)/.prefix ; } && cat $(GENERATED_DIR)/.prefix
+RANDOM_PREFIX != [ -e $(GENERATED_DIR)/.prefix ] || { mkdir -p $(GENERATED_DIR) && tr -dc a-z0-9 </dev/urandom | head -c 5 > $(GENERATED_DIR)/.prefix ; } && cat $(GENERATED_DIR)/.prefix
 
 export TF_DATA_DIR?=$(GENERATED_DIR)
 export TF_PLUGIN_CACHE_DIR?=$(GENERATED_DIR)/terraform-plugins


### PR DESCRIPTION
gke service account length limitation 

![image](https://github.com/aneoconsulting/ArmoniK/assets/113617172/373259af-1cf3-4395-89dc-a55d74aced86)

so we need to change generated RANDOM_PREFIX  from 10 to 5 random characters