### PR TITLE
feat: GKE with taints  - nomore autopilot by default

### DIFF
--- a/infrastructure/quick-deploy/gcp/all-in-one/gke.tf
+++ b/infrastructure/quick-deploy/gcp/all-in-one/gke.tf
@@ -15,10 +15,13 @@ module "gke" {
     }
   ]
   cluster_resource_labels    = local.labels
-  node_pools_labels          = local.node_pool_labels
-  node_pools_resource_labels = local.node_pool_labels
-  node_pools_tags            = local.node_pool_tags
-  private                    = false
+  node_pools_tags            = local.node_pools_tags
+  node_pools_labels          = local.node_pools_labels
+  node_pools_resource_labels = local.node_pools_labels
+  node_pools_taints          = var.gke.node_pools_taints
+  private                    = !var.gke.enable_public_gke_access
+  autopilot                  = var.gke.enable_gke_autopilot
+  node_pools                 = var.gke.node_pools
 }
 
 resource "kubernetes_namespace" "armonik" {

--- a/infrastructure/quick-deploy/gcp/all-in-one/parameters.tfvars
+++ b/infrastructure/quick-deploy/gcp/all-in-one/parameters.tfvars
@@ -1,5 +1,235 @@
-# labels for GCP labels
-labels = {}
+# GKE
+gke = {
+  enable_public_gke_access = true
+  enable_gke_autopilot     = false
+  node_pools_labels = {
+    workers = {
+      service = "workers"
+    }
+    metrics = {
+      service = "metrics"
+    }
+    control-plane = {
+      service = "control-plane"
+    }
+    monitoring = {
+      service = "monitoring"
+    }
+    state-database = {
+      service = "state-database"
+    }
+    others = {
+      service = "others"
+    }
+  }
+  node_pools_taints = {
+    workers = [
+      {
+        key    = "service"
+        value  = "workers"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+    metrics = [
+      {
+        key    = "service"
+        value  = "metrics"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+    control-plane = [
+      {
+        key    = "service"
+        value  = "control-plane"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+    monitoring = [
+      {
+        key    = "service"
+        value  = "monitoring"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+    state-database = [
+      {
+        key    = "service"
+        value  = "state-database"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+  }
+  node_pools = [
+    {
+      name             = "workers"
+      machine_type     = "e2-standard-8"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 0          # per zone. It is null if used alongside total_min_count
+      max_count                   = 1000       # per zone. It is null if used alongside total_max_count
+      total_min_count             = 0          # per NodePool
+      total_max_count             = 1000       # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = true
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "metrics"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 1          # per zone. It is null if used alongside total_min_count
+      max_count                   = 5          # per zone. It is null if used alongside total_max_count
+      total_min_count             = 1          # per NodePool
+      total_max_count             = 5          # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = false
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "control-plane"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 1          # per zone. It is null if used alongside total_min_count
+      max_count                   = 10         # per zone. It is null if used alongside total_max_count
+      total_min_count             = 1          # per NodePool
+      total_max_count             = 10         # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = false
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "monitoring"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 1          # per zone. It is null if used alongside total_min_count
+      max_count                   = 5          # per zone. It is null if used alongside total_max_count
+      total_min_count             = 1          # per NodePool
+      total_max_count             = 5          # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = false
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "state-database"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 1          # per zone. It is null if used alongside total_min_count
+      max_count                   = 10         # per zone. It is null if used alongside total_max_count
+      total_min_count             = 1          # per NodePool
+      total_max_count             = 10         # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = false
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "others"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 0
+      min_count                   = 0          # per zone. It is null if used alongside total_min_count
+      max_count                   = 100        # per zone. It is null if used alongside total_max_count
+      total_min_count             = 0          # per NodePool
+      total_max_count             = 100        # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = true
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    }
+  ]
+}
 
 kms = {
   key_ring   = "armonik-europe-west1"
@@ -110,7 +340,7 @@ admin_gui = {
 compute_plane = {
   # Default partition that uses the C# extension for the worker
   default = {
-    #node_selector = { service = "workers" }
+    node_selector = { service = "workers" }
     # number of replicas for each deployment of compute plane
     replicas = 1
     # ArmoniK polling agent

--- a/infrastructure/quick-deploy/gcp/all-in-one/variables.tf
+++ b/infrastructure/quick-deploy/gcp/all-in-one/variables.tf
@@ -60,8 +60,13 @@ variable "gke" {
       services_cidr_block = optional(string, "172.17.17.0/24")
       region              = optional(string, "europe-west1")
     }), {})
-    namespace       = optional(string, "armonik")
-    kubeconfig_file = optional(string, "generated/kubeconfig")
+    namespace                = optional(string, "armonik")
+    kubeconfig_file          = optional(string, "generated/kubeconfig")
+    enable_public_gke_access = optional(bool, true)
+    enable_gke_autopilot     = optional(bool, false)
+    node_pools_labels        = optional(map(map(string)), null)
+    node_pools_taints        = optional(map(list(object({ key = string, value = string, effect = string }))), null)
+    node_pools               = optional(list(map(any)), null)
   })
   default = {}
 }

--- a/infrastructure/quick-deploy/gcp/multi-stages/armonik/parameters.tfvars
+++ b/infrastructure/quick-deploy/gcp/multi-stages/armonik/parameters.tfvars
@@ -47,7 +47,7 @@ control_plane = {
 compute_plane = {
   # Default partition that uses the C# extension for the worker
   default = {
-    #node_selector = { service = "workers" }
+    node_selector = { service = "workers" }
     # number of replicas for each deployment of compute plane
     replicas = 1
     # ArmoniK polling agent

--- a/infrastructure/quick-deploy/gcp/multi-stages/gke/Makefile
+++ b/infrastructure/quick-deploy/gcp/multi-stages/gke/Makefile
@@ -37,8 +37,6 @@ apply:
 		-var 'region=$(REGION)' \
 		-var 'suffix=$(SUFFIX)' \
 		-var 'project=$(GCP_PROJECT_ID)' \
-		-var 'enable_public_gke_access=$(PUBLIC_ACCESS_GKE)' \
-		-var 'kubeconfig_file=$(KUBECONFIG)' \
 		-state $(STATE_FILE) \
 		-auto-approve
 
@@ -55,8 +53,6 @@ delete:
 		-var 'region=$(REGION)' \
 		-var 'suffix=$(SUFFIX)' \
 		-var 'project=$(GCP_PROJECT_ID)' \
-		-var 'enable_public_gke_access=$(PUBLIC_ACCESS_GKE)' \
-		-var 'kubeconfig_file=$(KUBECONFIG)' \
 		-state $(STATE_FILE) \
 		-auto-approve
 

--- a/infrastructure/quick-deploy/gcp/multi-stages/gke/parameters.tfvars
+++ b/infrastructure/quick-deploy/gcp/multi-stages/gke/parameters.tfvars
@@ -9,4 +9,235 @@ kms = {
   crypto_key = "armonik-europe-west1"
 }
 
-labels = {}
+# GKE
+gke = {
+  enable_public_gke_access = true
+  enable_gke_autopilot     = false
+  node_pools_labels = {
+    workers = {
+      service = "workers"
+    }
+    metrics = {
+      service = "metrics"
+    }
+    control-plane = {
+      service = "control-plane"
+    }
+    monitoring = {
+      service = "monitoring"
+    }
+    state-database = {
+      service = "state-database"
+    }
+    others = {
+      service = "others"
+    }
+  }
+  node_pools_taints = {
+    workers = [
+      {
+        key    = "service"
+        value  = "workers"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+    metrics = [
+      {
+        key    = "service"
+        value  = "metrics"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+    control-plane = [
+      {
+        key    = "service"
+        value  = "control-plane"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+    monitoring = [
+      {
+        key    = "service"
+        value  = "monitoring"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+    state-database = [
+      {
+        key    = "service"
+        value  = "state-database"
+        effect = "NO_SCHEDULE"
+      }
+    ]
+  }
+  node_pools = [
+    {
+      name             = "workers"
+      machine_type     = "e2-standard-8"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 0          # per zone. It is null if used alongside total_min_count
+      max_count                   = 1000       # per zone. It is null if used alongside total_max_count
+      total_min_count             = 0          # per NodePool
+      total_max_count             = 1000       # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = true
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "metrics"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 1          # per zone. It is null if used alongside total_min_count
+      max_count                   = 5          # per zone. It is null if used alongside total_max_count
+      total_min_count             = 1          # per NodePool
+      total_max_count             = 5          # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = false
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "control-plane"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 1          # per zone. It is null if used alongside total_min_count
+      max_count                   = 10         # per zone. It is null if used alongside total_max_count
+      total_min_count             = 1          # per NodePool
+      total_max_count             = 10         # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = false
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "monitoring"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 1          # per zone. It is null if used alongside total_min_count
+      max_count                   = 5          # per zone. It is null if used alongside total_max_count
+      total_min_count             = 1          # per NodePool
+      total_max_count             = 5          # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = false
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "state-database"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 1
+      min_count                   = 1          # per zone. It is null if used alongside total_min_count
+      max_count                   = 10         # per zone. It is null if used alongside total_max_count
+      total_min_count             = 1          # per NodePool
+      total_max_count             = 10         # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = false
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    },
+    {
+      name             = "others"
+      machine_type     = "e2-medium"
+      image_type       = "COS_CONTAINERD"
+      min_cpu_platform = ""
+      # or see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones
+      autoscaling                 = true
+      node_count                  = null # should not be used alongside autoscaling
+      max_pods_per_node           = 110
+      initial_node_count          = 0
+      min_count                   = 0          # per zone. It is null if used alongside total_min_count
+      max_count                   = 100        # per zone. It is null if used alongside total_max_count
+      total_min_count             = 0          # per NodePool
+      total_max_count             = 100        # per NodePool
+      location_policy             = "BALANCED" # or ANY
+      auto_repair                 = true
+      auto_upgrade                = true
+      enable_gcfs                 = false
+      enable_gvnic                = false
+      logging_variant             = "DEFAULT"
+      local_ssd_count             = 0
+      disk_size_gb                = 100
+      disk_type                   = "pd-standard"
+      spot                        = true
+      boot_disk_kms_key           = ""
+      enable_secure_boot          = false
+      enable_integrity_monitoring = true
+    }
+  ]
+}

--- a/infrastructure/quick-deploy/gcp/multi-stages/gke/variables.tf
+++ b/infrastructure/quick-deploy/gcp/multi-stages/gke/variables.tf
@@ -52,9 +52,16 @@ variable "kubeconfig_file" {
   default     = "generated/kubeconfig"
 }
 
-# Enable EKS public access
-variable "enable_public_gke_access" {
-  description = "Enable GKE public access"
-  type        = bool
-  default     = true
+# GCP Kubernetes cluster
+variable "gke" {
+  description = "GKE cluster configuration"
+  type = object({
+    enable_public_gke_access = optional(bool, true)
+    enable_gke_autopilot     = optional(bool, false)
+    kubeconfig_file          = optional(string, "generated/kubeconfig")
+    node_pools_labels        = optional(map(map(string)), null)
+    node_pools_taints        = optional(map(list(object({ key = string, value = string, effect = string }))), null)
+    node_pools               = optional(list(map(any)), null)
+  })
+  default = {}
 }


### PR DESCRIPTION
objectives : 
- Do not use GKE autopilot cluster by default
- Add taints/label/toleration on different node/pods types

Here after all-in-one deployment + htcmock run results
![image](https://github.com/aneoconsulting/ArmoniK/assets/113617172/1434be34-027d-4071-9f64-56dc213a3454)

FYI repport request :
`echo "*** NODE TAINTS BEFORE RUN : ***" && \
echo -e "Nodes Name :\tService :\tTaints :" | awk -F$'\t' '{printf "%-60s %-20s %-20s\n", $1, $2, $3}' && kubectl get nodes  -o jsonpath="{range .items[*]}{.metadata.name}{'\t'}{.metadata.labels.service}{'\t'}{.spec.taints[?(@.key == 'service')]} {'\n'}{end}"  | awk -F$'\t' '{printf "%-60s %-20s %-20s\n", $1, $2, $3}' && \
echo "*** LAUNCHING HTCMOCK TESTS : ***" && \
export grpc_endpoint=$(kubectl get services -n armonik ingress -o jsonpath={.status.loadBalancer.ingress[0].ip}) && \
docker run --rm -e GrpcClient__Endpoint=http://${grpc_endpoint}:5001 -e HtcMock__Partition=htcmock -e HtcMock__NTasks=500 -e HtcMock__TotalCalculationTime=00:00:30.000 -e HtcMock__DataSize=1 -e HtcMock__MemorySize=1 -e HtcMock__SubTasksLevels=1 -e HtcMock__EnableUseLowMem=true -e HtcMock__EnableSmallOutput=true -e HtcMock__EnableFastCompute=true dockerhubaneo/armonik_core_htcmock_test_client:0.20.3 && \
echo "*** NODE TAINTS AFTER RUN : ***" && \
echo -e "Nodes Name :\tService :\tTaints :" | awk -F$'\t' '{printf "%-60s %-20s %-20s\n", $1, $2, $3}' && kubectl get nodes  -o jsonpath="{range .items[*]}{.metadata.name}{'\t'}{.metadata.labels.service}{'\t'}{.spec.taints[?(@.key == 'service')]} {'\n'}{end}"  | awk -F$'\t' '{printf "%-60s %-20s %-20s\n", $1, $2, $3}' && \
echo "*** PODS TOLERATIONS : ***" && \
echo -e "Pod Name :\tService :\tTolerations :" | awk -F$'\t' '{printf "%-40s %-20s %-20s\n", $1, $2, $3}' && kubectl get pods -n armonik -o jsonpath="{range .items[?(@.metadata.labels.service!='')]}{ .metadata.name }{'\t'}{.metadata.labels.service}{'\t'}{ .spec.tolerations[?(@.key == 'service')]}{'\n'}{end}" | awk -F$'\t' '{printf "%-40s %-20s %-20s\n", $1, $2, $3}'
`
