### PR TITLE
refactor: adapt quick-deploy for refactored mongodb module

### DIFF
--- a/infrastructure/quick-deploy/aws/storage.tf
+++ b/infrastructure/quick-deploy/aws/storage.tf
@@ -166,11 +166,13 @@ module "mongodb" {
   source    = "./generated/infra-modules/storage/onpremise/mongodb"
   namespace = local.namespace
   mongodb = {
-    image              = local.ecr_images["${var.mongodb.image_name}:${try(coalesce(var.mongodb.image_tag), "")}"].name
-    tag                = local.ecr_images["${var.mongodb.image_name}:${try(coalesce(var.mongodb.image_tag), "")}"].tag
-    node_selector      = var.mongodb.node_selector
-    image_pull_secrets = var.mongodb.pull_secrets
-    replicas_number    = var.mongodb.replicas_number
+    image                 = local.ecr_images["${var.mongodb.image_name}:${try(coalesce(var.mongodb.image_tag), "")}"].name
+    tag                   = local.ecr_images["${var.mongodb.image_name}:${try(coalesce(var.mongodb.image_tag), "")}"].tag
+    node_selector         = var.mongodb.node_selector
+    image_pull_secrets    = var.mongodb.pull_secrets
+    replicas              = var.mongodb.replicas
+    helm_chart_repository = try(coalesce(var.mongodb.helm_chart_repository), var.helm_charts.mongodb.repository)
+    helm_chart_version    = try(coalesce(var.mongodb.helm_chart_version), var.helm_charts.mongodb.version)
   }
 
   persistent_volume = var.mongodb.persistent_volume != null ? {
@@ -359,7 +361,7 @@ locals {
     } : null
     mongodb = {
       url                = module.mongodb.url
-      number_of_replicas = var.mongodb.replicas_number
+      number_of_replicas = var.mongodb.replicas
     }
     shared = {
       service_url = "https://s3.${var.region}.amazonaws.com"

--- a/infrastructure/quick-deploy/aws/variables.tf
+++ b/infrastructure/quick-deploy/aws/variables.tf
@@ -315,11 +315,14 @@ variable "mq_credentials" {
 variable "mongodb" {
   description = "Parameters of MongoDB"
   type = object({
-    image_name      = optional(string, "mongo")
-    image_tag       = optional(string)
-    node_selector   = optional(any, {})
-    pull_secrets    = optional(string, "")
-    replicas_number = optional(number, 1)
+    image_name            = optional(string, "bitnami/mongodb")
+    image_tag             = optional(string)
+    node_selector         = optional(any, {})
+    pull_secrets          = optional(string, "")
+    replicas              = optional(number, 1)
+    helm_chart_repository = optional(string)
+    helm_chart_version    = optional(string)
+
     persistent_volume = optional(object({
       storage_provisioner = string
       volume_binding_mode = optional(string, "Immediate")
@@ -334,6 +337,7 @@ variable "mongodb" {
         }))
       }), {})
     }))
+
     security_context = optional(object({
       run_as_user = optional(number, 999)
       fs_group    = optional(number, 999)

--- a/infrastructure/quick-deploy/gcp/variables.tf
+++ b/infrastructure/quick-deploy/gcp/variables.tf
@@ -111,11 +111,13 @@ variable "chaos_mesh" {
 variable "mongodb" {
   description = "Parameters of MongoDB"
   type = object({
-    image_name      = optional(string, "mongo")
-    image_tag       = optional(string)
-    node_selector   = optional(any, {})
-    pull_secrets    = optional(string, "")
-    replicas_number = optional(number, 1)
+    image_name            = optional(string, "bitnami/mongodb")
+    image_tag             = optional(string)
+    node_selector         = optional(any, {})
+    pull_secrets          = optional(string, "")
+    replicas              = optional(number, 1)
+    helm_chart_repository = optional(string)
+    helm_chart_version    = optional(string)
   })
   default = {}
 }

--- a/infrastructure/quick-deploy/localhost/storage.tf
+++ b/infrastructure/quick-deploy/localhost/storage.tf
@@ -26,11 +26,13 @@ module "mongodb" {
   source    = "./generated/infra-modules/storage/onpremise/mongodb"
   namespace = local.namespace
   mongodb = {
-    image              = var.mongodb.image_name
-    tag                = try(coalesce(var.mongodb.image_tag), local.default_tags[var.mongodb.image_name])
-    node_selector      = var.mongodb.node_selector
-    image_pull_secrets = var.mongodb.image_pull_secrets
-    replicas_number    = var.mongodb.replicas_number
+    image                 = var.mongodb.image_name
+    tag                   = try(coalesce(var.mongodb.image_tag), local.default_tags[var.mongodb.image_name])
+    node_selector         = var.mongodb.node_selector
+    image_pull_secrets    = var.mongodb.image_pull_secrets
+    replicas              = var.mongodb.replicas
+    helm_chart_repository = try(coalesce(var.mongodb.helm_chart_repository), var.helm_charts.mongodb.repository)
+    helm_chart_version    = try(coalesce(var.mongodb.helm_chart_version), var.helm_charts.mongodb.version)
   }
   persistent_volume = null
 }
@@ -181,10 +183,10 @@ locals {
       host               = module.mongodb.host
       port               = module.mongodb.port
       credentials        = module.mongodb.user_credentials
-      certificates       = module.mongodb.user_certificate
       endpoints          = module.mongodb.endpoints
-      number_of_replicas = var.mongodb.replicas_number
+      number_of_replicas = var.mongodb.replicas
       allow_insecure_tls = true
+      #certificates       = module.mongodb.user_certificate
     }
     shared = var.shared_storage != null ? var.shared_storage : {
       host_path         = abspath("data")

--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -135,11 +135,13 @@ variable "rabbitmq" {
 variable "mongodb" {
   description = "Parameters of MongoDB"
   type = object({
-    image_name         = optional(string, "mongo")
-    image_tag          = optional(string)
-    node_selector      = optional(any, {})
-    image_pull_secrets = optional(string, "")
-    replicas_number    = optional(number, 1)
+    image_name            = optional(string, "bitnami/mongodb")
+    image_tag             = optional(string)
+    node_selector         = optional(any, {})
+    image_pull_secrets    = optional(string, "")
+    replicas              = optional(number, 1)
+    helm_chart_repository = optional(string)
+    helm_chart_version    = optional(string)
   })
   default = {}
 }

--- a/tools/access-mongo-as-admin.sh
+++ b/tools/access-mongo-as-admin.sh
@@ -1,8 +1,0 @@
-#! /bin/sh
-
-# ACESS to monogodb as admin
-MPASS="$(kubectl get secret -n armonik mongodb-admin -o jsonpath="{.data.password}" | base64 --decode)"
-MUSER="$(kubectl get secret -n armonik mongodb-admin -o jsonpath="{.data.username}" | base64 --decode)"
-kubectl get secret -n armonik mongodb-user-certificates -o jsonpath="{.data.chain\.pem}" | base64 --decode > ./mongodb_chain.pem
-MONGO_IP="$(kubectl get svc mongodb-0 -n armonik -o custom-columns="IP:.spec.clusterIP" --no-headers=true)"
-docker run -it -v "$(pwd)/mongodb_chain.pem:/chain.pem" --rm rtsp/mongosh mongosh --tlsCAFile /chain.pem --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls -u "$MUSER" -p "$MPASS" "mongodb://$MONGO_IP:27017"

--- a/tools/access-mongo-as-user.sh
+++ b/tools/access-mongo-as-user.sh
@@ -1,8 +1,0 @@
-#! /bin/sh
-
-# ACESS to monogodb as user
-MPASS="$(kubectl get secret -n armonik mongodb-user -o jsonpath="{.data.password}" | base64 --decode)"
-MUSER="$(kubectl get secret -n armonik mongodb-user -o jsonpath="{.data.username}" | base64 --decode)"
-kubectl get secret -n armonik mongodb-user-certificates -o jsonpath="{.data.chain\.pem}" | base64 --decode > ./mongodb_chain.pem
-MONGO_IP="$(kubectl get svc mongodb-0 -n armonik -o custom-columns="IP:.spec.clusterIP" --no-headers=true)"
-docker run -it -v "$(pwd)/mongodb_chain.pem:/chain.pem" --rm rtsp/mongosh mongosh --tlsCAFile /chain.pem --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls -u "$MUSER" -p "$MPASS" "mongodb://$MONGO_IP:27017/database" #--eval 'db.serverStatus()'

--- a/tools/access-mongo-from-kubernetes-as-user.sh
+++ b/tools/access-mongo-from-kubernetes-as-user.sh
@@ -7,10 +7,7 @@ cat <<EOF
 ***** This script allows you to connect to mongo directly from inside the cluster => useful for AWS installation *****
 **********************************************************************************************************************
 
-1 - Firstly you have to connect to db :
-  use database
-
-2 - You can execute requests ex :
+- You can execute requests ex :
 - Display all TaskData :
   db.TaskData.find().limit(3).pretty()
 - Filter by  session / output :
@@ -44,23 +41,23 @@ kubectl run -it --rm -n armonik mongoshclient --image=rtsp/mongosh --overrides='
           "-c"
         ],
         "args": [
-          "mongosh --tlsCAFile /mongodb/chain.pem --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD mongodb+srv://mongodb-armonik-headless.armonik.svc.cluster.local/"
+          "mongosh --tlsCAFile /mongodb/chain.pem --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls -u $MONGO_USERNAME -p $MONGO_USER_PASSWORD mongodb+srv://mongodb-armonik-headless.armonik.svc.cluster.local/database"
         ],
         "env": [
           {
-            "name": "MONGO_INITDB_ROOT_USERNAME",
+            "name": "MONGO_USERNAME",
             "valueFrom": {
               "secretKeyRef": {
-                "name": "mongodb-admin",
+                "name": "mongodb-user",
                 "key": "username"
               }
             }
           },
           {
-            "name": "MONGO_INITDB_ROOT_PASSWORD",
+            "name": "MONGO_USER_PASSWORD",
             "valueFrom": {
               "secretKeyRef": {
-                "name": "mongodb-admin",
+                "name": "mongodb-user",
                 "key": "password"
               }
             }

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,7 +1,7 @@
 {
   "armonik_versions": {
     "armonik":       "2.20.0",
-    "infra":         "0.4.3",
+    "infra":         "0.5.0-pre-2-d48d300",
     "infra_plugins": "0.1.0",
     "core":          "0.24.2",
     "api":           "3.18.1",
@@ -58,6 +58,7 @@
     "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner":  "v4.0.0-eks-1-29-8",
     "symptoma/activemq":                                              "5.18.3",
     "mongo":                                                          "7.0.5",
+    "bitnami/mongodb":                                                "7.0.12-debian-12-r0",
     "redis":                                                          "7.2.5-alpine",
     "minio/minio":                                                    "RELEASE.2024-05-10T01-41-38Z",
     "datalust/seq":                                                   "2024.3",
@@ -68,7 +69,7 @@
     "rtsp/mongosh":                                                   "2.2.6",
     "nginxinc/nginx-unprivileged":                                    "1.25.5-alpine-slim",
     "datalust/seqcli":                                                "2024.3",
-    "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner":         "v4.0.2",
+    "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner":    "v4.0.2",
     "bitnami/rabbitmq":                                               "3.12.14",
     "ghcr.io/chaos-mesh/chaos-mesh":                                  "v2.6.3",
     "ghcr.io/chaos-mesh/chaos-daemon":                                "v2.6.3",
@@ -81,6 +82,7 @@
     "termination_handler" : {"repository" : "https://aws.github.io/eks-charts" , "version" : "0.21.0" },
     "efs_csi_driver" : { "repository" :"https://kubernetes-sigs.github.io/aws-efs-csi-driver/" , "version": "2.5.7" },
     "rabbitmq" : { "repository" : "https://charts.bitnami.com/bitnami" , "version" : "13.0.2"},
-    "chaos_mesh" : { "repository" : "https://charts.chaos-mesh.org" , "version" : "2.6.3"}
+    "chaos_mesh" : { "repository" : "https://charts.chaos-mesh.org" , "version" : "2.6.3"},
+    "mongodb" : { "repository": "oci://registry-1.docker.io/bitnamicharts", "version" : "15.6.12"}
   }
 }


### PR DESCRIPTION
This pull request aims to modify the way the mongodb module is called in the quick-deploy modules (aws, gcp and onpremise/localhost) following this PR in the ArmoniK.Infra repo : https://github.com/aneoconsulting/ArmoniK.Infra/pull/140

It adds the two attributes `helm_chart_repository` and `helm_chart_version` that are now needed to call the mongodb module, and it also changes the default value for the mongodb image used, from `mongo` to `bitnami/mongodb`, as the refactored module was developed with the intent to use the latter image.

Additionnaly, it modifies the versions.tfvars.json file to use the adequate version of ArmoniK.Infra, refactoring the maps `armonik_images.image_tags` and `armonik_images.helm_charts` for the deployment to retrieve the correct mongodb image and helm chart to use.

Finally, it also adapts some connection scripts tools.

**WARNING : This PR break AWS deployment, the patch for this break is soon to be pushed, on both ArmoniK and ArmoniK.Infra repositories**
