### PR TITLE
fix: Fix AWS deployment

### DIFF
--- a/infrastructure/quick-deploy/aws/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/parameters.tfvars
@@ -272,7 +272,7 @@ mq = {
 
 mongodb = {
   node_selector = { service = "state-database" }
-  # Uncomment persitent_volume to enable persistence, comment to disable
+  # Uncomment persistent_volume to enable persistence, comment to disable
   #persistent_volume = {
   #  storage_provisioner = "efs.csi.aws.com"
   #  resources = {

--- a/infrastructure/quick-deploy/aws/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/parameters.tfvars
@@ -272,6 +272,7 @@ mq = {
 
 mongodb = {
   node_selector = { service = "state-database" }
+  # Uncomment persitent_volume to enable persistence, comment to disable
   #persistent_volume = {
   #  storage_provisioner = "efs.csi.aws.com"
   #  resources = {

--- a/infrastructure/quick-deploy/aws/storage.tf
+++ b/infrastructure/quick-deploy/aws/storage.tf
@@ -125,6 +125,7 @@ module "mq" {
   source          = "./generated/infra-modules/storage/aws/mq"
   tags            = local.tags
   name            = "${local.prefix}-mq"
+  namespace       = local.namespace
   vpc_id          = local.vpc.id
   vpc_cidr_blocks = local.vpc.cidr_blocks
   vpc_subnet_ids  = local.vpc.subnet_ids

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,7 +1,7 @@
 {
   "armonik_versions": {
     "armonik":       "2.20.0",
-    "infra":         "0.5.0-pre-2-d48d300",
+    "infra":         "0.5.0-pre-3-ec0487a",
     "infra_plugins": "0.1.0",
     "core":          "0.24.2",
     "api":           "3.18.1",


### PR DESCRIPTION
This PR intends to fix the AWS deployment which was broke by https://github.com/aneoconsulting/ArmoniK/pull/1293 .

The break happened to be caused an incapacity of defining a custom volume provisionning mechanism or of disabling persistence. The Helm chart used to define a storage class based on an EBS provisionner which is not automatically present in the EKS.

This PR integrates the fix on [ArmoniK.Infra](https://github.com/aneoconsulting/ArmoniK.Infra) introduced by https://github.com/aneoconsulting/ArmoniK.Infra/pull/153 .