### PR TITLE
feat: Parametrization of MongoDB persistence for localhost and GCP

### DIFF
--- a/infrastructure/quick-deploy/gcp/parameters.tfvars
+++ b/infrastructure/quick-deploy/gcp/parameters.tfvars
@@ -252,6 +252,8 @@ keda = {
 
 mongodb = {
   node_selector = { service = "state-database" }
+  # Uncomment the line below to enable persistence, comment to disable
+  # persistent_volume = {}
 }
 
 # Nullify to disable sharding, each nullification of subobject will result in the use of default values 

--- a/infrastructure/quick-deploy/gcp/storage.tf
+++ b/infrastructure/quick-deploy/gcp/storage.tf
@@ -28,7 +28,7 @@ module "mongodb" {
   }
   mongodb_resources = var.mongodb.mongodb_resources
   arbiter_resources = var.mongodb.arbiter_resources
-  persistent_volume = null
+  persistent_volume = var.mongodb.persistent_volume
 }
 
 module "mongodb_sharded" {

--- a/infrastructure/quick-deploy/gcp/variables.tf
+++ b/infrastructure/quick-deploy/gcp/variables.tf
@@ -128,7 +128,7 @@ variable "mongodb" {
       limits   = optional(map(string))
       requests = optional(map(string))
     }))
-    
+
     persistent_volume = optional(object({
       storage_provisioner = optional(string)
       volume_binding_mode = optional(string, "Immediate")

--- a/infrastructure/quick-deploy/gcp/variables.tf
+++ b/infrastructure/quick-deploy/gcp/variables.tf
@@ -128,6 +128,21 @@ variable "mongodb" {
       limits   = optional(map(string))
       requests = optional(map(string))
     }))
+    
+    persistent_volume = optional(object({
+      storage_provisioner = optional(string)
+      volume_binding_mode = optional(string, "Immediate")
+      parameters          = optional(map(string), {})
+      #Resources for PVC
+      resources = optional(object({
+        limits = optional(object({
+          storage = string
+        }))
+        requests = optional(object({
+          storage = string
+        }))
+      }))
+    }))
   })
   default = {}
 }

--- a/infrastructure/quick-deploy/localhost/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/parameters.tfvars
@@ -342,6 +342,9 @@ mongodb = {
   #     "ephemeral-storage" = "500Mi"
   #   }
   # }
+
+  # Uncomment the line below to enable persistence, comment to disable
+  # persistent_volume = {}
 }
 
 # Nullify to disable sharding

--- a/infrastructure/quick-deploy/localhost/storage.tf
+++ b/infrastructure/quick-deploy/localhost/storage.tf
@@ -37,7 +37,7 @@ module "mongodb" {
   }
   mongodb_resources = var.mongodb.mongodb_resources
   arbiter_resources = var.mongodb.arbiter_resources
-  persistent_volume = null
+  persistent_volume = var.mongodb.persistent_volume
 }
 
 module "mongodb_sharded" {

--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -152,6 +152,21 @@ variable "mongodb" {
       limits   = optional(map(string))
       requests = optional(map(string))
     }))
+
+    persistent_volume = optional(object({
+      storage_provisioner = optional(string)
+      volume_binding_mode = optional(string, "Immediate")
+      parameters          = optional(map(string), {})
+      #Resources for PVC
+      resources = optional(object({
+        limits = optional(object({
+          storage = string
+        }))
+        requests = optional(object({
+          storage = string
+        }))
+      }))
+    }))
   })
   default = {}
 }


### PR DESCRIPTION
# Motivation

Based on the new feature introduced by https://github.com/aneoconsulting/ArmoniK.Infra/pull/153, this PR enables different persistence configuration for both localhost and GCP deployments, as it is already done for AWS.

# Description

It includes a new object persistent_volume in the mongodb variable. If it is null, persistence is disabled as it was before, else, persistence is enabled under the condition that the configuration provided fits you cluster.

# Testing

Deployed on GCP and localhost.

# Impact

More flexibility with MongoDB persistence for GCP and localhost.

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] I have thoroughly tested my modifications and added tests when necessary.
- [X] Tests pass locally and in the CI.
- [X] I have assessed the performance impact of my modifications.
