### PR TITLE
fix: change minio default bucket name

### DIFF
--- a/infrastructure/quick-deploy/localhost/common.tf
+++ b/infrastructure/quick-deploy/localhost/common.tf
@@ -20,7 +20,7 @@ locals {
   minio_s3_fs_image              = try(var.minio_s3_fs.image, "minio/minio")
   minio_s3_fs_image_pull_secrets = try(var.minio_s3_fs.image_pull_secrets, "")
   minio_s3_fs_host               = try(var.minio_s3_fs.host, "minio_s3_fs")
-  minio_s3_fs_bucket_name        = try(var.minio_s3_fs.default_bucket, "minioBucket")
+  minio_s3_fs_bucket_name        = try(var.minio_s3_fs.default_bucket, "minio-bucket")
   minio_s3_fs_node_selector      = try(var.minio_s3_fs.node_selector, {})
   shared_storage_minio_s3_fs = var.minio_s3_fs != null ? {
     file_storage_type     = "s3"

--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -180,7 +180,7 @@ variable "minio" {
     image_tag          = optional(string)
     node_selector      = optional(any, {})
     image_pull_secrets = optional(string, "")
-    default_bucket     = optional(string, "minioBucket")
+    default_bucket     = optional(string, "minio-bucket")
     host               = optional(string, "minio")
   })
   default = null
@@ -194,7 +194,7 @@ variable "minio_s3_fs" {
     image_tag          = optional(string)
     node_selector      = optional(any, {})
     image_pull_secrets = optional(string, "")
-    default_bucket     = optional(string, "minioBucket")
+    default_bucket     = optional(string, "minio-bucket")
     host               = optional(string, "minio-s3-fs")
   })
   default = null


### PR DESCRIPTION
This PR is to fix the minio default bucket name from `minioBucket` which is not conforming to the Bucket naming rules (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) leading to `The specified bucket is not valid` error.
