### PR TITLE
feat: Armonik with GPU acceleration on AWS

### DIFF
--- a/infrastructure/quick-deploy/aws/variables.tf
+++ b/infrastructure/quick-deploy/aws/variables.tf
@@ -656,14 +656,8 @@ variable "compute_plane" {
       image             = string
       tag               = optional(string)
       image_pull_policy = optional(string, "IfNotPresent")
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string)
-      }))
-      requests = optional(object({
-        cpu    = optional(string)
-        memory = optional(string)
-      }))
+      limits            = optional(map(string))
+      requests          = optional(map(string))
       #conf
       conf = optional(any, [])
     }))


### PR DESCRIPTION
**Description of the Changes:**

This update introduces a new node group specifically designed for running ArmoniK workers on GPU instances. Key changes include:

- **GPU Node Group Creation:** A new gpu_workers node group is added, configured to run on NVIDIA GPU instances (g4dn.xlarge) using the Bottlerocket AMI. Taints and labels are applied to ensure that only GPU-specific workloads are scheduled on these nodes.

- **GPU Workload Partition:** A new gputest partition is introduced, which directs workloads requiring GPU acceleration to the gpu_workers node group. This includes setting resource requests and limits tailored for GPU tasks.

- **Changed Resource Definitions:** The structure of resource limit and request definitions for compute plane workers has been changed to fit the request for GPU instances by converting them into a map format without being constrained to predefined keys.