### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# Motivation
+
+[Include the reason behind these changes and any relevant context.]
+
+# Description
+
+[Provide a detailled explanation of the modifications you have made. Link any related issues.]
+
+# Testing
+
+[When applicable, detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]
+
+# Impact
+
+[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]
+
+# Additional Information
+
+[Any additional information that reviewers should be aware of.]
+
+# Checklist
+
+- [ ] My code adheres to the coding and style guidelines of the project.
+- [ ] I have performed a self-review of my code.
+- [ ] I have commented my code, particularly in hard-to-understand areas.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have thoroughly tested my modifications and added tests when necessary.
+- [ ] Tests pass locally and in the CI.
+- [ ] I have assessed the performance impact of my modifications.


### PR DESCRIPTION
# Motivation

Pull request templates encourage developers to document their works better, either on the reasons behind the developments or on their impact, or even on some technical specifications.

# Description

Adds a PR template that will be automatically in use at each PR on this repo. This template is based on [this one](https://github.com/aneoconsulting/ArmoniK.Core/blob/0.27.1/.github/PULL_REQUEST_TEMPLATE.md) in the ArmoniK.Core repository.
Original idea from https://github.com/pieterherman-dev/PR-Template-Guide/tree/main?tab=readme-ov-file

# Testing

# Impact

It is intended to enhance this repository documentation and thus quality of code.

# Additional Information
 
Already in use in [ArmoniK.Core repository](https://github.com/aneoconsulting/ArmoniK.Core)

# Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [X] I have assessed the performance impact of my modifications.