### PR TITLE
feat: Prometheus metrics export and import

### DIFF
--- a/tools/metrics/README.md
+++ b/tools/metrics/README.md
@@ -1,0 +1,19 @@
+
+
+This folder contains a set of tools that can be used to analyse ArmoniK metrics. 
+
+It's currently split into two folders, `export/` and `import/`
+
+#### Export
+
+This folder contains a shell script `export-prometheus-s3.sh` that can be used to export ArmoniK's metrics from Prometheus to an S3 bucket. The script has two modes. 
+- When the `--local` argument is supplied, the script functions by using a `kubectl cp` command. This is ideal for local deployments. You only need to have made sure to export your kubeconfig, as well as have your aws cli configured (you don't need to supply any credentials)
+- Otherwise, the script will run a Kubernetes Job. The job requires you to have ta Persistent Volume configured for Prometheus for it to work. Moreover, you need to supply AWS CLI credentials either as parameters to the script or for you to have them exported as environment variables. Ofcourse, exporting your kubeconfig is essential to be able to apply your job
+
+Running the script with no arguments will provide a short help message containing the arguments that you can supply it. 
+
+#### Import
+
+This folder contains a docker-compose deployment containing Prometheus and Grafana which you can just `docker compose up -d` to deploy. Additionally, there is a script that can facilitate importing Prometheus data from S3 and extracting it. You only need to provide the complete s3 filepath and optionally the AWS profile that you want to use. 
+
+Similarly, running the script with no arguments will provide a short help message containing the arguments that you can supply it. 

--- a/tools/metrics/export/export-prometheus-s3.sh
+++ b/tools/metrics/export/export-prometheus-s3.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 [-a AWS_ACCESS_KEY_ID] [-s AWS_SECRET_ACCESS_KEY] [-t AWS_SESSION_TOKEN] [-n KUBERNETES_NAMESPACE] -f FILENAME -b BUCKET_NAME [--local]"
+    exit 1
+}
+
+# Initialize variables
+AWS_ACCESS_KEY_ID_ARG=""
+AWS_SECRET_ACCESS_KEY_ARG=""
+AWS_SESSION_TOKEN_ARG=""
+FILENAME=""
+BUCKET_NAME=""
+KUBE_NAMESPACE="armonik"
+LOCAL_MODE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -a) AWS_ACCESS_KEY_ID_ARG="$2"; shift ;;
+        -s) AWS_SECRET_ACCESS_KEY_ARG="$2"; shift ;;
+        -t) AWS_SESSION_TOKEN_ARG="$2"; shift ;;
+        -f) FILENAME="$2"; shift ;;
+        -b) BUCKET_NAME="$2"; shift ;;
+        -n) KUBE_NAMESPACE="$2"; shift ;;
+        --local) LOCAL_MODE=true;;
+        *) usage ;;
+    esac
+    shift
+done
+
+# Validate mandatory arguments
+if [[ -z "$FILENAME" || -z "$BUCKET_NAME" || -z "$KUBE_NAMESPACE" ]]; then
+    usage
+fi
+
+# Use environment variables if set, otherwise use provided arguments
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$AWS_ACCESS_KEY_ID_ARG}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$AWS_SECRET_ACCESS_KEY_ARG}"
+AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-$AWS_SESSION_TOKEN_ARG}"
+
+if $LOCAL_MODE; then
+    echo "Using Kubernetes copy."
+
+    # Find the name of the Prometheus pod
+    PROMETHEUS_POD=$(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n "$KUBE_NAMESPACE" | grep '^prometheus')
+    if [[ -z "$PROMETHEUS_POD" ]]; then
+        echo "Error: No pod found starting with 'prometheus'."
+        exit 1
+    fi
+
+    echo "Found Prometheus pod: $PROMETHEUS_POD"
+
+    # Copy the directory from the pod
+    kubectl cp "$PROMETHEUS_POD:/prometheus/" "$FILENAME" -n "$KUBE_NAMESPACE" || {
+        echo "Error: Failed to copy file from pod.";
+        exit 1;
+    }
+    echo "Data directory copied from pod successfully."
+
+    # Tar the driectory
+    TAR_FILE="${FILENAME}.tar.gz"
+    tar -czf "$TAR_FILE" "$FILENAME" || {
+        echo "Error: Failed to create tar file.";
+        exit 1;
+    }
+    echo "Directory tarred successfully: $TAR_FILE"
+
+    # Upload the tar file to AWS S3
+    aws s3 cp "$TAR_FILE" "s3://$BUCKET_NAME/" || {
+        echo "Error: Failed to upload tar file to S3.";
+        exit 1;
+    }
+    echo "File uploaded to S3 bucket successfully: s3://$BUCKET_NAME/$TAR_FILE"
+
+    # Clean up
+    rm -f "$TAR_FILE" "$FILENAME" || {
+        echo "Error: Failed to clean up temporary files.";
+        exit 1;
+    }
+    echo "Cleaned up temporary files."
+
+else
+    echo "Using Persistent Volume."
+
+    # Check if AWS credentials are provided
+    if [[ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+        echo "Error: AWS credentials are not set in the environment or provided as arguments."
+        usage
+    fi
+
+    # Read the template file
+    TEMPLATE_FILE="prom-export.yml"
+    if [[ ! -f "$TEMPLATE_FILE" ]]; then
+        echo "Error: Template file '$TEMPLATE_FILE' not found."
+        exit 1
+    fi
+
+    # Apply the Kubernetes Job
+    echo "Applying Kubernetes Job:"
+    sed -e "s|{{KUBE_NAMESPACE}}|$KUBE_NAMESPACE|g" \
+    -e "s|{{AWS_ACCESS_KEY_ID}}|$AWS_ACCESS_KEY_ID|g" \
+    -e "s|{{AWS_SECRET_ACCESS_KEY}}|$AWS_SECRET_ACCESS_KEY|g" \
+    -e "s|{{AWS_SESSION_TOKEN}}|$AWS_SESSION_TOKEN|g" \
+    -e "s|{{FILENAME}}|$FILENAME|g" \
+    -e "s|{{KUBERNETES_NAMESPACE}}|$KUBE_NAMESPACE|g" \
+    -e "s|{{BUCKET_NAME}}|$BUCKET_NAME|g" | kubectl apply -f - || {
+        echo "Error: Failed to apply Kubernetes Job.";
+        exit 1;
+    }
+    echo "Kubernetes Job applied successfully."
+fi

--- a/tools/metrics/export/prom-export.yml
+++ b/tools/metrics/export/prom-export.yml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prom-s3
+  namespace: {{KUBERNETES_NAMESPACE}}
+spec:
+  template:
+    spec:
+      containers:
+      - name: prom-snap
+        image: richarvey/awscli:latest
+        env:
+          - name: "AWS_ACCESS_KEY_ID"
+            value: "{{AWS_ACCESS_KEY_ID}}"
+          - name: "AWS_SECRET_ACCESS_KEY"
+            value: "{{AWS_SECRET_ACCESS_KEY}}"
+          - name: "AWS_SESSION_TOKEN"
+            value: "{{AWS_SESSION_TOKEN}}"
+        command: ["sh", "-c", "tar -czvf /tmp/{{FILENAME}}.tar.gz /prometheus && aws s3 cp /tmp/{{FILENAME}}.tar.gz s3://{{BUCKET_NAME}}/{{FILENAME}}.tar.gz"]
+        volumeMounts:
+        - name: prometheus-volume
+          mountPath: /prometheus
+      restartPolicy: Never
+      volumes:
+      - name: prometheus-volume
+        persistentVolumeClaim:
+          claimName: prometheus
+      ttlSecondsAfterFinished: 120
+  backoffLimit: 4

--- a/tools/metrics/import/configs/grafana.yml
+++ b/tools/metrics/import/configs/grafana.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/tools/metrics/import/configs/prometheus.yml
+++ b/tools/metrics/import/configs/prometheus.yml
@@ -1,0 +1,2 @@
+global:
+  scrape_interval: 1m

--- a/tools/metrics/import/docker-compose.yml
+++ b/tools/metrics/import/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.8'
+
+networks:
+  monitoring:
+    driver: bridge
+
+services:
+  init_prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus_prestart
+    user: root
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        chown -R 65534:65534 /prometheus
+    volumes:
+      - ./data/prometheus/:/prometheus/
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    volumes:
+      - ./configs/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./data/prometheus/:/prometheus/
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus/'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    expose:
+      - 9090
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring
+    depends_on:
+      - init_prometheus
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    restart: always
+    networks:
+      - monitoring
+    volumes:
+      - ./configs/grafana.yml:/etc/grafana/provisioning/datasource.yml
+
+    

--- a/tools/metrics/import/import-prometheus-s3.sh
+++ b/tools/metrics/import/import-prometheus-s3.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+usage() {
+    # TODO: Optionally being able to provide a different path to save the files to other than default
+    echo "Usage: $0 [--profile AWS_PROFILE] -f FILE_PATH"
+    exit 1
+}
+
+# Initialize variables
+AWS_PROFILE=""
+FILE_PATH=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --profile) AWS_PROFILE="$2"; shift;;
+        -f) FILE_PATH="$2"; shift ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+echo "Using AWS_PROFILE=$AWS_PROFILE"
+
+if [[ -z "$FILE_PATH" ]]; then 
+    echo "Need to supply the s3 path to the prometheus data"
+    usage 
+fi
+
+prom_data_dir=$(dirname "$(realpath "$0")")
+
+mkdir -p "$prom_data_dir/temp"
+
+# Delete and recreate the data directory
+if [[ -d "$prom_data_dir/data" ]]; then
+    echo "Data directory exists. Attempting to delete..."
+    sudo rm -rf "$prom_data_dir/data"
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Failed to delete the data directory. Check permissions."
+        exit 1
+    fi
+fi
+
+mkdir -p "$prom_data_dir/data"
+echo "Data directory recreated."
+
+if [[ -z $AWS_PROFILE ]]; then 
+    aws s3 cp "$FILE_PATH" "$prom_data_dir/temp"
+else 
+    aws s3 cp "$FILE_PATH" "$prom_data_dir/temp" --profile "$AWS_PROFILE"
+fi
+
+# Check if the AWS command was successful
+if [[ $? -ne 0 ]]; then
+    echo "Error: Failed to download file from S3. Exiting."
+    exit 1
+fi
+
+file_name=$(basename "$FILE_PATH")
+tar -xvzf "$prom_data_dir/temp/$file_name" -C "$prom_data_dir/data"
+
+if [[ $? -eq 0 ]]; then
+    echo "Extraction successful. Cleaning up..."
+    rm -rf "$prom_data_dir/temp/"
+else
+    echo "Error during extraction."
+    exit 1
+fi
+
+echo "File extracted to: $prom_data_dir/data"
+echo "Run 'docker compose up -d' to deploy Prometheus and Grafana locally" 


### PR DESCRIPTION
# Motivation


Prometheus metrics are usually lost after ArmoniK infra gets destroyed. This PR includes scripts to save this data so it can be looked at and analyzed later on.

# Description

This PR introduces a script that can be ran to export the data from Prometheus into an S3 bucket (at the end of github workflows for example). Along with a minimal monitoring deployment that current just includes Grafana and Prometheus, with a script that can be used to quickly import back previous Prometheus data into this deployment so it can be studied/analyzed.

# Testing

Scripts were tested on both local and AWS deployments.

# Impact

Not relevant. 

# Additional Information

Check README.md for additional information.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.