### PR TITLE
fix: keda variable issues

### DIFF
--- a/infrastructure/quick-deploy/gcp/keda.tf
+++ b/infrastructure/quick-deploy/gcp/keda.tf
@@ -8,8 +8,8 @@ module "keda" {
   }
   image_pull_secrets              = var.keda.pull_secrets
   node_selector                   = var.keda.node_selector
-  helm_chart_repository           = try(coalesce(var.keda.helm_chart_repository), var.helm_charts.repository)
-  helm_chart_version              = try(coalesce(var.keda.helm_chart_version), var.helm_charts.version)
+  helm_chart_repository           = try(coalesce(var.keda.helm_chart_repository), var.helm_charts.keda.repository)
+  helm_chart_version              = try(coalesce(var.keda.helm_chart_version), var.helm_charts.keda.version)
   metrics_server_dns_policy       = var.keda.metrics_server_dns_policy
   metrics_server_use_host_network = var.keda.metrics_server_use_host_network
 }

--- a/infrastructure/quick-deploy/gcp/variables.tf
+++ b/infrastructure/quick-deploy/gcp/variables.tf
@@ -81,8 +81,8 @@ variable "keda" {
     node_selector                   = optional(any, {})
     metrics_server_dns_policy       = optional(string, "ClusterFirst")
     metrics_server_use_host_network = optional(bool, false)
-    helm_chart_repository           = optional(string, "https://kedacore.github.io/charts")
-    helm_chart_version              = optional(string, "2.9.4")
+    helm_chart_repository           = optional(string)
+    helm_chart_version              = optional(string)
   })
   default = {}
 }

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,7 +1,7 @@
 {
   "armonik_versions": {
     "armonik":       "2.20.0",
-    "infra":         "0.5.1-pre-2-e62c928",
+    "infra":         "0.6.1-pre1-fbd66b9",
     "infra_plugins": "0.1.1",
     "core":          "0.27.2",
     "api":           "3.19.0",


### PR DESCRIPTION
# Motivation

Deployments of newer versions of keda fail

# Description

A variable has been introduced in the keda chart helm with default value to ghcr.io. We need to expose this variable in our deployment so that we can update it when dealing with private registries. Also the default variable for the keda chart helm version was used. The used of the defined version needs to be fixed.


# Testing


# Impact


# Additional Information


# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.