### PR TITLE
feat: Added script and kubernetes job to export mongodb collections to S3

### DIFF
--- a/tools/metrics/export/export-mongodb-s3.sh
+++ b/tools/metrics/export/export-mongodb-s3.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 [-a AWS_ACCESS_KEY_ID] [-s AWS_SECRET_ACCESS_KEY] [-t AWS_SESSION_TOKEN] [-n KUBERNETES_NAMESPACE] -f FILENAME -b BUCKET_NAME "
+    exit 1
+}
+
+# Initialize variables
+AWS_ACCESS_KEY_ID_ARG=""
+AWS_SECRET_ACCESS_KEY_ARG=""
+AWS_SESSION_TOKEN_ARG=""
+FILENAME=""
+BUCKET_NAME=""
+KUBE_NAMESPACE="armonik"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -a) AWS_ACCESS_KEY_ID_ARG="$2"; shift ;;
+        -s) AWS_SECRET_ACCESS_KEY_ARG="$2"; shift ;;
+        -t) AWS_SESSION_TOKEN_ARG="$2"; shift ;;
+        -f) FILENAME="$2"; shift ;;
+        -b) BUCKET_NAME="$2"; shift ;;
+        -n) KUBE_NAMESPACE="$2"; shift ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+# Validate mandatory arguments
+if [[ -z "$FILENAME" || -z "$BUCKET_NAME" ]]; then
+    usage
+fi
+
+# Use environment variables if set, otherwise use provided arguments
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$AWS_ACCESS_KEY_ID_ARG}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$AWS_SECRET_ACCESS_KEY_ARG}"
+AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-$AWS_SESSION_TOKEN_ARG}"
+
+
+echo "Exporting MongoDB database"
+
+# Check if AWS credentials are provided
+if [[ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+    echo "Error: AWS credentials are not set in the environment or provided as arguments."
+    usage
+fi
+
+# Read the template file
+TEMPLATE_FILE="mongo-export.yml"
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+    echo "Error: Template file '$TEMPLATE_FILE' not found."
+    exit 1
+fi
+
+# Apply the Kubernetes Job
+echo "Applying Kubernetes Job:"
+    sed -e "s|{{KUBE_NAMESPACE}}|$KUBE_NAMESPACE|g" \
+    -e "s|{{AWS_ACCESS_KEY_ID}}|$AWS_ACCESS_KEY_ID|g" \
+    -e "s|{{AWS_SECRET_ACCESS_KEY}}|$AWS_SECRET_ACCESS_KEY|g" \
+    -e "s|{{AWS_SESSION_TOKEN}}|$AWS_SESSION_TOKEN|g" \
+    -e "s|{{FILENAME}}|$FILENAME|g" \
+    -e "s|{{BUCKET_NAME}}|$BUCKET_NAME|g" | kubectl apply -f - || {
+    echo "Error: Failed to apply Kubernetes Job.";
+    exit 1;
+}
+echo "Kubernetes Job applied successfully."

--- a/tools/metrics/export/mongo-export.yml
+++ b/tools/metrics/export/mongo-export.yml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongo-export
+  namespace: {{KUBE_NAMESPACE}}
+spec:
+  template:
+    spec:
+      containers:
+      - name: sling
+        image: slingdata/sling
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Use the environment variables directly
+            export MONGODB="mongodb://$MONGO_USER:$MONGO_PASS@$MONGO_HOST:$MONGO_PORT/?authSource=database"
+
+            # Run the Sling command
+            sling run --src-conn MONGODB --src-stream 'database.TaskData' --tgt-conn S3 --tgt-object "s3://{{BUCKET_NAME}}/{{FILENAME}}_TaskData.json"
+        env:
+          - name: MONGO_USER
+            valueFrom:
+              secretKeyRef:
+                name: custom-mongodb-sharded
+                key: username
+          - name: MONGO_PASS
+            valueFrom:
+              secretKeyRef:
+                name: custom-mongodb-sharded
+                key: password
+          - name: MONGO_HOST
+            valueFrom:
+              secretKeyRef:
+                name: custom-mongodb-sharded
+                key: host
+          - name: MONGO_PORT
+            valueFrom:
+              secretKeyRef:
+                name: custom-mongodb-sharded
+                key: port
+          - name: "AWS_ACCESS_KEY_ID"
+            value: "{{AWS_ACCESS_KEY_ID}}"
+          - name: "AWS_SECRET_ACCESS_KEY"
+            value: "{{AWS_SECRET_ACCESS_KEY}}"
+          - name: "AWS_SESSION_TOKEN"
+            value: "{{AWS_SESSION_TOKEN}}"
+        volumeMounts:
+          - name: mongodb-cert
+            mountPath: /mongodb/certs
+            readOnly: true
+      restartPolicy: Never
+      volumes:
+        - name: mongodb-cert
+          secret:
+            secretName: custom-mongodb-sharded
+            items:
+              - key: chain.pem
+                path: chain.pem
+  backoffLimit: 4


### PR DESCRIPTION
# Motivation

To further our ability to analyze the behavior of ArmoniK, this PR introduces a script to export TaskData (and later on other MongoDB collections) to an S3 bucket. They can be importer later on onto another MongoDB setup using mongo-tools (a separate PR with a script for that) or ideally just work with the JSON file directly or using a smaller database (such as TinyDB) to analyze the data.

# Description

This PR introduces a shell script and a kubernetes job that makes use of Sling to export MongoDB data to an S3 bucket. 

# Testing

Tested on both an AWS and localhost deployment of ArmoniK.

# Impact

Not Applicable.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.