### PR TITLE
fix: Changed clone depth of get-modules to 1

### DIFF
--- a/infrastructure/quick-deploy/aws/Makefile
+++ b/infrastructure/quick-deploy/aws/Makefile
@@ -98,11 +98,10 @@ kubeconfig:
 
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --all --tags;\
+		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
-		git -C $(MODULES_DIR) pull origin $(MODULES_VERSION);\
     else \
-      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) $(MODULES_SOURCE) $(MODULES_DIR);\
+      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
     fi
 
 clean:

--- a/infrastructure/quick-deploy/gcp/Makefile
+++ b/infrastructure/quick-deploy/gcp/Makefile
@@ -98,11 +98,10 @@ kubeconfig:
 
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --all --tags;\
+		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
-		git -C $(MODULES_DIR) pull origin $(MODULES_VERSION);\
     else \
-      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) $(MODULES_SOURCE) $(MODULES_DIR);\
+      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
     fi
 
 clean:

--- a/infrastructure/quick-deploy/localhost/Makefile
+++ b/infrastructure/quick-deploy/localhost/Makefile
@@ -60,11 +60,10 @@ output:
 
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --all --tags;\
+		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
-		git -C $(MODULES_DIR) pull origin $(MODULES_VERSION);\
     else \
-      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) $(MODULES_SOURCE) $(MODULES_DIR);\
+      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
     fi
 
 clean:


### PR DESCRIPTION
# Motivation

Running `make deploy` sometimes fails at the `get-modules` stage because of internet speed, and takes a long time to run.

# Description

Instead of fetching the entire ArmoniK.Infra repository (which can take a long time), we fetch only the latest commit of the version we're trying to use.

# Testing

Deployed ArmoniK with it on localhost, but it should be the same for aws/gcp.

# Impact

Slightly faster deployment on slower internets.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.