### PR TITLE
chore: add script to force delete a namespace

### DIFF
--- a/tools/force-delete-namespace.sh
+++ b/tools/force-delete-namespace.sh
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+namespace="${1:?Namespace not defined}"
+
+echo -n "Force deleting a namespace can leave some resources associated to the namespace alive.\nAre you sure you want to delete the namespace \`$namespace\`? [y/N] " >&2
+
+read -r answer
+
+case "$answer" in
+  y|Y|yes|Yes)
+    echo "Deleting namespace \`$namespace\`"
+    ;;
+  n|N|no|No|"")
+    echo Abort >&2
+    exit 1
+    ;;
+  *)
+    echo "Unrecognized answer \`$answer\`: it should be either yes or no.\nAbort" >&2
+    exit 2
+    ;;
+esac
+
+kubectl delete namespaces "$namespace" --force --grace-period=0 --timeout=10s || {
+  kubectl proxy --port=1337 & pid=$!
+  sleep 1
+
+  curl -fsS "http://localhost:1337/api/v1/namespaces/$namespace" |
+    jq '.spec.finalizers = []' |
+    curl -fsS -XPUT -H 'Content-Type: application/json' "http://localhost:1337/api/v1/namespaces/$namespace/finalize" -d @-
+
+  kill $pid
+}


### PR DESCRIPTION
# Motivation

Sometimes, when destruction goes wrong, the kubernetes namespace might end up being undeletable by conventional means. In those cases, even `kubectl delete namespace NAME --force --grace-period=0` does nothing.

# Description

Add a script to remove all the finalizers of the namespace to tell kubernetes that the namespace has now been finalized.

# Impact

This script should be used only as a last resort as it might leave resources alive.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.