### PR TITLE
chore: Add hibernate option to destroy a deployment but keep images

### DIFF
--- a/infrastructure/quick-deploy/aws/Makefile
+++ b/infrastructure/quick-deploy/aws/Makefile
@@ -76,6 +76,9 @@ refresh:
 delete:
 	terraform destroy -var-file=$(VERSIONS_FILE) -var-file=$(PARAMETERS_FILE) -var-file=$(EXTRA_PARAMETERS_FILE) -auto-approve
 
+hibernate:
+	terraform destroy -var-file=$(VERSIONS_FILE) -var-file=$(PARAMETERS_FILE) -var-file=$(EXTRA_PARAMETERS_FILE) -auto-approve -target=module.vpc -target=module.eks -target=module.mq -target=module.s3_os -target=module.elasticache
+
 state-pull:
 	terraform state pull
 

--- a/infrastructure/quick-deploy/gcp/Makefile
+++ b/infrastructure/quick-deploy/gcp/Makefile
@@ -87,6 +87,9 @@ refresh:
 delete:
 	terraform destroy -var-file=$(VERSIONS_FILE) -var-file=$(PARAMETERS_FILE) -var-file=$(EXTRA_PARAMETERS_FILE) -auto-approve
 
+hibernate:
+	terraform destroy -var-file=$(VERSIONS_FILE) -var-file=$(PARAMETERS_FILE) -var-file=$(EXTRA_PARAMETERS_FILE) -auto-approve -target=module.vpc -target=module.gke -target=module.gcs_os -target=module.memorystore
+
 output:
 	@terraform output -state=$(STATE_FILE) -json | jq 'map_values(.value)' > $(OUTPUT_FILE)
 	@echo "\nOUTPUT FILE: $(OUTPUT_FILE)"


### PR DESCRIPTION
# Motivation

When deploying on AWS or GCP, the upload of the images can take a long time, or might even fail because of docker rate limit.

# Description

Add a `hibernate` command to the Makefile in order to destroy all the expensive resources (compute, redis, queue), but keep inexpensive resources, and especially keep the images in the private registry.

# Testing

Deploying after an hibernate works as intended on AWS. GCP has not been testing yet.

# Impact

When hibernate is used, the following deployment is much faster because the images are already there. Hibernate leaves some resources around.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.