### PR TITLE
fix: unshard MongoDB in default deployments

### DIFF
--- a/infrastructure/quick-deploy/aws/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/parameters.tfvars
@@ -303,7 +303,7 @@ mongodb = {
 }
 
 # Nullify to disable sharding, each nullification of subobject will result in the use of default values 
-mongodb_sharding = {}
+# mongodb_sharding = {}
 
 seq = {
   node_selector = { service = "monitoring" }

--- a/infrastructure/quick-deploy/gcp/parameters.tfvars
+++ b/infrastructure/quick-deploy/gcp/parameters.tfvars
@@ -255,7 +255,7 @@ mongodb = {
 }
 
 # Nullify to disable sharding, each nullification of subobject will result in the use of default values 
-mongodb_sharding = {}
+# mongodb_sharding = {}
 
 #memorystore = {
 #  memory_size_gb = 20

--- a/infrastructure/quick-deploy/localhost/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/parameters.tfvars
@@ -345,4 +345,4 @@ mongodb = {
 }
 
 # Nullify to disable sharding
-mongodb_sharding = {}
+# mongodb_sharding = {}


### PR DESCRIPTION
# Motivation

As our deployment of sharded MongoDB is not considered fully stable, it should not be deployed by default.

# Description

Simply comments the lines where variable `mongodb_sharding` is defined in the `parameters.tfvars`.

# Testing

Our "classical" MongoDB deployment is considered much more stable.

# Impact

Default deployments will be much more stable.

# Additional Information


# Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [X] I have assessed the performance impact of my modifications.