### PR TITLE
chore: update active mq version to 5.18.6 in aws

### DIFF
--- a/infrastructure/quick-deploy/aws/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/parameters.tfvars
@@ -294,7 +294,7 @@ elasticache = {
 
 mq = {
   engine_type        = "ActiveMQ"
-  engine_version     = "5.17.6"
+  engine_version     = "5.18.6"
   host_instance_type = "mq.m5.xlarge"
 }
 


### PR DESCRIPTION
# Motivation

AWS Health triggered the reminder notification to update the engine version of active mq version in amazon mq. Amazon MQ will end support for the version 5.17 on June 16, 2025. 

# Description

Update the engine version from 5.17.6 to maintained version 5.18.6.

# Testing

The deployed should run successfully.

# Impact

No impact remarkable except the modification made by the new version.

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.