### PR TITLE
fix: add RabbitMQ module to core configurations in Armonik deployment

### DIFF
--- a/infrastructure/quick-deploy/localhost/armonik.tf
+++ b/infrastructure/quick-deploy/localhost/armonik.tf
@@ -4,7 +4,7 @@ module "armonik" {
   logging_level = var.logging_level
 
   configurations = merge(var.configurations, {
-    core = [module.activemq, module.redis, module.mongodb, module.mongodb_sharded, var.configurations.core]
+    core = [module.activemq, module.rabbitmq, module.redis, module.mongodb, module.mongodb_sharded, var.configurations.core]
   })
 
   fluent_bit              = module.fluent_bit


### PR DESCRIPTION
# Motivation

Implement RabbitMQ module in the core configurations for **localhost** in order to deploy ArmoniK, 

# Description

The module RabbitMQ was missing in the Core configuration and we were unable to deploy Armonik using RabbitMQ as queue

# Testing

Tested locally and htcmock tests were ran.

# Impact

Ability to use RabbitMQ as queue to deploy Armonik locally.

# Additional Information

None

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.