### PR TITLE
fix: Avoid locking Infra to a single tag

### DIFF
--- a/infrastructure/quick-deploy/aws/Makefile
+++ b/infrastructure/quick-deploy/aws/Makefile
@@ -106,9 +106,9 @@ get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
 		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
-    else \
-      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
-    fi
+	else \
+		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
+	fi
 
 clean:
 	rm -rf $(TF_DATA_DIR) .terraform.lock.hcl .terraform

--- a/infrastructure/quick-deploy/gcp/Makefile
+++ b/infrastructure/quick-deploy/gcp/Makefile
@@ -106,9 +106,9 @@ get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
 		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
-    else \
-      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
-    fi
+	else \
+		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
+	fi
 
 clean:
 	rm -rf $(TF_DATA_DIR) .terraform.lock.hcl .terraform

--- a/infrastructure/quick-deploy/localhost/Makefile
+++ b/infrastructure/quick-deploy/localhost/Makefile
@@ -65,9 +65,9 @@ get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
 		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
-    else \
-      	git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
-    fi
+	else \
+		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
+	fi
 
 clean:
 	rm -rf $(TF_DATA_DIR) .terraform.lock.hcl .terraform


### PR DESCRIPTION
# Motivation

Shallow clone of the infra (https://github.com/aneoconsulting/ArmoniK/pull/1342) introduced a bug where it is impossible to change branch after the first `make get-modules`.

# Description

Add option in clone to avoid locking the remote to a single branch/tag.

# Testing

This has been tested locally by removing the `generated/infra-modules` folder, calling `make get-modules`, modifying the infra version, and recalling `make get-modules`.

# Impact

This fix only works if the infra has not been fetched yet.
If you have already fetched the infra by calling make, you can either remove the `generated/infra-modules` folder,
or calling the following command from the `generated/infra-modules` folder:

```sh
git remote set-branches origin '*'
```

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.