### PR TITLE
feat: Added hint to export CLI config

### DIFF
--- a/infrastructure/quick-deploy/aws/Makefile
+++ b/infrastructure/quick-deploy/aws/Makefile
@@ -28,8 +28,8 @@ export TF_VAR_prefix?=$(PREFIX)
 
 .PHONY: apply destroy
 
-all: get-modules init apply output kubeconfig
-deploy: get-modules init apply output kubeconfig
+all: get-modules init apply output cliconfig kubeconfig
+deploy: get-modules init apply output cliconfig kubeconfig
 destroy: init delete
 
 env:
@@ -101,6 +101,11 @@ kubeconfig:
 	@echo "Execute the following commands:"
 	@echo "------------------------------"
 	@echo "export KUBECONFIG=$(shell cat $(GENERATED_DIR)/armonik-output.json | jq -r '.eks.kubeconfig_file')"
+
+cliconfig:
+	@echo "Run to point your ArmoniK CLI to this deployment:"
+	@echo "------------------------------"
+	@echo "export AKCONFIG=$(GENERATED_DIR)/armonik-cli.yaml"
 
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\

--- a/infrastructure/quick-deploy/gcp/Makefile
+++ b/infrastructure/quick-deploy/gcp/Makefile
@@ -29,8 +29,8 @@ SHELL:=/bin/bash
 
 .PHONY: apply destroy
 
-all: get-modules init apply output kubeconfig
-deploy: get-modules init apply output kubeconfig
+all: get-modules init apply output cliconfig kubeconfig
+deploy: get-modules init apply output cliconfig kubeconfig
 destroy: init delete
 
 env:
@@ -101,6 +101,11 @@ kubeconfig:
 	@echo "Execute the following commands:"
 	@echo "------------------------------"
 	@echo "export KUBECONFIG=$(shell cat $(GENERATED_DIR)/armonik-output.json | jq -r '.gke.kubeconfig_file')"
+
+cliconfig:
+	@echo "Run to point your ArmoniK CLI to this deployment:"
+	@echo "------------------------------"
+	@echo "export AKCONFIG=$(GENERATED_DIR)/armonik-cli.yaml"
 
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\

--- a/infrastructure/quick-deploy/localhost/Makefile
+++ b/infrastructure/quick-deploy/localhost/Makefile
@@ -19,8 +19,8 @@ export TF_VAR_prefix?=$(PREFIX)
 
 .PHONY: apply destroy
 
-all: get-modules init apply output
-deploy: get-modules init apply output
+all: get-modules init apply output cliconfig
+deploy: get-modules init apply output cliconfig
 destroy: init delete
 
 env:
@@ -74,3 +74,8 @@ clean:
 
 docs:
 	terraform-docs markdown table --output-file parameters.md --output-mode inject $(CURRENT_DIR)
+
+cliconfig:
+	@echo "Run to point your ArmoniK CLI to this deployment:"
+	@echo "------------------------------"
+	@echo "export AKCONFIG=$(GENERATED_DIR)/armonik-cli.yaml"


### PR DESCRIPTION
# Motivation

Need a way to tell the user to export the generated config file path for the ArmoniK CLI.

# Description

Changed previous commands to signal for this, and added a fix for the SAN.

# Testing

Tested locally.

# Impact

Not applicable.

# Additional Information

Requires [#208](https://github.com/aneoconsulting/ArmoniK.Infra/pull/208) to be merged.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.