### PR TITLE
fix: Enable MongoDB persistence by default on Localhost

### DIFF
--- a/infrastructure/quick-deploy/localhost/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/parameters.tfvars
@@ -348,9 +348,14 @@ mongodb = {
   #   }
   # }
 
-  # Uncomment the line below to enable persistence, comment to disable
-  # persistent_volume = {}
+  # Comment the line below to diable persistence
+  persistent_volume = {}
 }
 
-# Nullify to disable sharding
-# mongodb_sharding = {}
+# Uncomment to enable sharding
+# mongodb_sharding = {
+#   persistence = {
+#     shards = {}
+#     configsvr = {}
+#   }
+# }

--- a/infrastructure/quick-deploy/localhost/storage.tf
+++ b/infrastructure/quick-deploy/localhost/storage.tf
@@ -93,6 +93,23 @@ module "mongodb_sharded" {
     configsvr = try(coalesce(var.mongodb_sharding.configsvr.labels), null)
     router    = try(coalesce(var.mongodb_sharding.router.labels), null)
   }
+
+  persistence = can(try(coalesce(var.mongodb_sharding.persistence), coalesce(var.mongodb.persistent_volume))) ? {
+    shards = can(try(coalesce(var.mongodb_sharding.persistence.shards), coalesce(var.mongodb.persistent_volume))) ? {
+      storage_provisioner = try(coalesce(var.mongodb_sharding.persistence.shards.storage_provisioner), coalesce(var.mongodb.persistent_volume.storage_provisioner), null)
+      volume_binding_mode = try(coalesce(var.mongodb_sharding.persistence.shards.volume_binding_mode), coalesce(var.mongodb.persistent_volume.volume_binding_mode), null)
+      reclaim_policy      = try(coalesce(var.mongodb_sharding.persistence.shards.reclaim_policy), coalesce(var.mongodb.persistent_volume.reclaim_policy), null)
+      resources           = try(coalesce(var.mongodb_sharding.persistence.shards.resources), coalesce(var.mongodb.persistent_volume.resources), null)
+      parameters          = try(coalesce(var.mongodb_sharding.persistence.shards.parameters), coalesce(var.mongodb.persistent_volume.parameters), null)
+    } : null
+    configsvr = can(coalesce(var.mongodb_sharding.persistence.configsvr)) ? {
+      storage_provisioner = var.mongodb_sharding.persistence.configsvr.storage_provisioner
+      volume_binding_mode = var.mongodb_sharding.persistence.configsvr.volume_binding_mode
+      reclaim_policy      = var.mongodb_sharding.persistence.configsvr.reclaim_policy
+      resources           = var.mongodb_sharding.persistence.configsvr.resources
+      parameters          = var.mongodb_sharding.persistence.configsvr.parameters
+    } : null
+  } : null
 }
 
 # Redis

--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -225,6 +225,42 @@ variable "mongodb_sharding" {
       }))
       labels = optional(map(string))
     }))
+
+    persistence = optional(object({
+      shards = optional(object({
+        access_mode         = optional(list(string), ["ReadWriteOnce"])
+        reclaim_policy      = optional(string, "Delete")
+        storage_provisioner = optional(string)
+        volume_binding_mode = optional(string, "WaitForFirstConsumer")
+        parameters          = optional(map(string))
+
+        resources = optional(object({
+          limits = optional(object({
+            storage = string
+          }))
+          requests = optional(object({
+            storage = string
+          }))
+        }))
+      }), {})
+
+      configsvr = optional(object({
+        access_mode         = optional(list(string), ["ReadWriteOnce"])
+        reclaim_policy      = optional(string, "Delete")
+        storage_provisioner = optional(string)
+        volume_binding_mode = optional(string, "WaitForFirstConsumer")
+        parameters          = optional(map(string))
+
+        resources = optional(object({
+          limits = optional(object({
+            storage = string
+          }))
+          requests = optional(object({
+            storage = string
+          }))
+        }))
+      }), {})
+    }))
   })
   default = null
 }


### PR DESCRIPTION
# Motivation

Persistence is not enabled by default on Localhost.

# Description

Expose persistence option for sharding, and make persitence the default.

# Testing

This has been tested locally. Data remains available even if pods are deleted manually, or if the helm chart is updated to a compatible version (same minor), or if the mongodb image is updated.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.