### PR TITLE
fix: Fetch tag in make get-modules

### DIFF
--- a/infrastructure/quick-deploy/aws/Makefile
+++ b/infrastructure/quick-deploy/aws/Makefile
@@ -109,7 +109,8 @@ cliconfig:
 
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
+		git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) ||\
+		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ;\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
 	else \
 		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\

--- a/infrastructure/quick-deploy/gcp/Makefile
+++ b/infrastructure/quick-deploy/gcp/Makefile
@@ -109,7 +109,8 @@ cliconfig:
 
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
+		git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) ||\
+		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ;\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
 	else \
 		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\

--- a/infrastructure/quick-deploy/localhost/Makefile
+++ b/infrastructure/quick-deploy/localhost/Makefile
@@ -63,7 +63,8 @@ output:
 
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION);\
+		git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) ||\
+		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ;\
 		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
 	else \
 		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\


### PR DESCRIPTION
# Motivation

The command `git fetch` does not fetch anything if the source is a tag.

# Description

Use the command `git fetch tag` to fetch the right infra version, and fallback to `git fetch` in case the `MODULE_VERSION` is not a tag but a branch.

# Testing

Works as expected.

# Additional Information

This is a continuation of https://github.com/aneoconsulting/ArmoniK/pull/1367

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.