### PR TITLE
docs: add correct for helloworld sample and partition doc

### DIFF
--- a/.docs/content/getting-started/execution/how-to-launch-HelloWorld-Sample.md
+++ b/.docs/content/getting-started/execution/how-to-launch-HelloWorld-Sample.md
@@ -18,7 +18,7 @@ Add a helloworld partition to [parameter.tfvar](https://github.com/aneoconsultin
 
 Copy the default one and change the partition name, add a tag to "latest", set the image to "hello".
 
-See the example [here](https://github.com/aneoconsulting/ArmoniK/blob/main/.docs/content/2.guide/1.how-to/how-to-configure-partitions.md).
+See the example [here](../../user-guide/how-to-configure-partitions.md).
 
 **Deploy** ArmoniK with `make` in `ArmoniK/infrastructure/quick-deploy/localhost`.
 

--- a/.docs/content/user-guide/how-to-configure-partitions.md
+++ b/.docs/content/user-guide/how-to-configure-partitions.md
@@ -211,7 +211,7 @@ It is an error to set the `PartitionId` to `null`.
 
 ## Add a partition for the HelloWorld worker
 
-Follow the HelloWorld tutorial [here](https://github.com/aneoconsulting/ArmoniK/blob/main/.docs/content/2.guide/how-to-launch-HelloWorld-Sample)
+Follow the HelloWorld tutorial [here](../getting-started/execution/how-to-launch-HelloWorld-Sample)
 
 ```terraform
 


### PR DESCRIPTION
# Motivation

Previously, some documentation links were unavailable or broken.

# Description

The links for "How to launch HelloWorld" and "How to configure partition" files now use relative paths pointing to the correct local files, replacing the previous GitHub repository URLs.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.