### PR TITLE
fix: remove dotnet 6 install and install docker only if not available

### DIFF
--- a/infrastructure/utils/scripts/installation/prerequisites-installer.sh
+++ b/infrastructure/utils/scripts/installation/prerequisites-installer.sh
@@ -67,11 +67,6 @@ echo "Installing k3s"
 "$DIR/install-k3s.sh"
 echo "K3s installed"
 
-# Install dotnet
-echo "Installing dotnet"
-"$DIR/install-dotnet.sh"
-echo "Dotnet installed"
-
 # Remove unused packages
 sudo apt autoremove -y
 

--- a/infrastructure/utils/scripts/installation/prerequisites/install-docker.sh
+++ b/infrastructure/utils/scripts/installation/prerequisites/install-docker.sh
@@ -1,4 +1,6 @@
 #! /bin/sh
 # This script is used to install docker
 
-sudo apt install docker.io
+if ! which docker >/dev/null 2>&1; then
+    sudo apt install docker.io
+fi

--- a/infrastructure/utils/scripts/installation/prerequisites/install-dotnet.sh
+++ b/infrastructure/utils/scripts/installation/prerequisites/install-dotnet.sh
@@ -1,5 +1,0 @@
-#! /bin/sh
-# This script is used to install dotnet.
-
-# https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu
-sudo apt -y install dotnet-sdk-6.0


### PR DESCRIPTION
# Motivation

Make the installation more robust.

# Description

- Remove dotnet installation as it not needed anymore to run samples shown in documentation. We use docker now.
- Check if docker is already installed before trying to install to avoid conflict between docker packages during installation.

# Testing

- The installation script was run on my machine and seems to work properly.
