### PR TITLE
feat: Added pymonik partitions to the reference deployments

### DIFF
--- a/infrastructure/quick-deploy/aws/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/parameters.tfvars
@@ -547,6 +547,57 @@ compute_plane = {
       ]
     }
   },
+  # Partition for the pymonik worker
+  pymonik = {
+    # number of replicas for each deployment of compute plane
+    replicas = 0
+    # ArmoniK polling agent
+    polling_agent = {
+      limits = {
+        cpu    = "2000m"
+        memory = "2048Mi"
+      }
+      requests = {
+        cpu    = "50m"
+        memory = "50Mi"
+      }
+    }
+    # ArmoniK workers
+    worker = [
+      {
+        image = "dockerhubaneo/harmonic_snake"
+        tag   = "python-3.10.12"
+        limits = {
+          cpu    = "1000m"
+          memory = "1024Mi"
+        }
+        requests = {
+          cpu    = "50m"
+          memory = "50Mi"
+        }
+      }
+    ]
+    hpa = {
+      type              = "prometheus"
+      polling_interval  = 15
+      cooldown_period   = 300
+      min_replica_count = 0
+      max_replica_count = 100
+      behavior = {
+        restore_to_original_replica_count = true
+        stabilization_window_seconds      = 300
+        type                              = "Percent"
+        value                             = 100
+        period_seconds                    = 15
+      }
+      triggers = [
+        {
+          type      = "prometheus"
+          threshold = 2
+        },
+      ]
+    }
+  },
   /*
   # Partition that run the workload on gpu
   gputest = {

--- a/infrastructure/quick-deploy/gcp/parameters.tfvars
+++ b/infrastructure/quick-deploy/gcp/parameters.tfvars
@@ -401,6 +401,57 @@ compute_plane = {
       ]
     }
   },
+  # Partition for the pymonik worker
+  pymonik = {
+    # number of replicas for each deployment of compute plane
+    replicas = 0
+    # ArmoniK polling agent
+    polling_agent = {
+      limits = {
+        cpu    = "2000m"
+        memory = "2048Mi"
+      }
+      requests = {
+        cpu    = "50m"
+        memory = "50Mi"
+      }
+    }
+    # ArmoniK workers
+    worker = [
+      {
+        image = "dockerhubaneo/harmonic_snake"
+        tag   = "python-3.10.12"
+        limits = {
+          cpu    = "1000m"
+          memory = "1024Mi"
+        }
+        requests = {
+          cpu    = "50m"
+          memory = "50Mi"
+        }
+      }
+    ]
+    hpa = {
+      type              = "prometheus"
+      polling_interval  = 15
+      cooldown_period   = 300
+      min_replica_count = 0
+      max_replica_count = 100
+      behavior = {
+        restore_to_original_replica_count = true
+        stabilization_window_seconds      = 300
+        type                              = "Percent"
+        value                             = 100
+        period_seconds                    = 15
+      }
+      triggers = [
+        {
+          type      = "prometheus"
+          threshold = 2
+        },
+      ]
+    }
+  },
   # Partition for the stream worker
   stream = {
     node_selector = { service = "workers" }

--- a/infrastructure/quick-deploy/localhost/parameters.tfvars
+++ b/infrastructure/quick-deploy/localhost/parameters.tfvars
@@ -113,6 +113,57 @@ compute_plane = {
       ]
     }
   },
+  # Partition for the pymonik worker
+  pymonik = {
+    # number of replicas for each deployment of compute plane
+    replicas = 0
+    # ArmoniK polling agent
+    polling_agent = {
+      limits = {
+        cpu    = "2000m"
+        memory = "2048Mi"
+      }
+      requests = {
+        cpu    = "50m"
+        memory = "50Mi"
+      }
+    }
+    # ArmoniK workers
+    worker = [
+      {
+        image = "dockerhubaneo/harmonic_snake"
+        tag   = "python-3.10.12"
+        limits = {
+          cpu    = "1000m"
+          memory = "1024Mi"
+        }
+        requests = {
+          cpu    = "50m"
+          memory = "50Mi"
+        }
+      }
+    ]
+    hpa = {
+      type              = "prometheus"
+      polling_interval  = 15
+      cooldown_period   = 300
+      min_replica_count = 0
+      max_replica_count = 5
+      behavior = {
+        restore_to_original_replica_count = true
+        stabilization_window_seconds      = 300
+        type                              = "Percent"
+        value                             = 100
+        period_seconds                    = 15
+      }
+      triggers = [
+        {
+          type      = "prometheus"
+          threshold = 2
+        },
+      ]
+    }
+  },
   # Partition for the stream worker
   stream = {
     # number of replicas for each deployment of compute plane


### PR DESCRIPTION
# Motivation

With the first version of PymoniK out. This PR aims to add pymonik partitions that use the latest available worker image. This would make it easier to get up and running with PymoniK (`make deploy` on localhost and then directly run your PymoniK code without additional work)

# Description

Added partitions that use the `harmonic_snake` worker image for the different reference deployments.

# Testing

Local deployment works, AWS was also tested, it should probably also work for GCP. 

# Impact

Make it easier to get up and running with PymoniK.

# Additional Information

This needs the PR on floating tags to be merged into the PymoniK repo in addition to creating a new PymoniK release. 

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.