### PR TITLE
fix: Add node-selector for pdc-updater

### DIFF
--- a/infrastructure/quick-deploy/aws/parameters.tfvars
+++ b/infrastructure/quick-deploy/aws/parameters.tfvars
@@ -455,6 +455,9 @@ fluent_bit_windows = {
   }
 }
 
+pod_deletion_cost = {
+  node_selector = { service = "metrics" }
+}
 
 # Logging level
 logging_level = "Information"


### PR DESCRIPTION
# Motivation

On AWS, the pod deletion cost updater had no node-selector, and was therefore deployed onto the others node pool.

# Description

Deploy the pdc-updater with the node selector `{ service = "metrics" }`

# Testing

Deploying on AWS works.

# Impact

Deployment should be cheaper because the `metrics` node will host the pdc-updater. It would also make the deployment more reliable during the destruction by avoiding network interfaces that are not destroyed with their nodes from the `others` pool.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.