### PR TITLE
fix: Propagate S3 configuration and fix permissions

### DIFF
--- a/infrastructure/quick-deploy/aws/armonik.tf
+++ b/infrastructure/quick-deploy/aws/armonik.tf
@@ -4,7 +4,7 @@ module "armonik" {
   logging_level = var.logging_level
 
   configurations = merge(var.configurations, {
-    core = [module.sqs, module.activemq, module.mq, module.elasticache, module.mongodb, module.mongodb_sharded, var.configurations.core]
+    core = [module.sqs, module.activemq, module.mq, module.elasticache, module.s3_os, module.mongodb, module.mongodb_sharded, var.configurations.core]
   })
 
   fluent_bit              = module.fluent_bit

--- a/infrastructure/quick-deploy/aws/storage.tf
+++ b/infrastructure/quick-deploy/aws/storage.tf
@@ -371,7 +371,7 @@ resource "aws_iam_policy" "object" {
 resource "aws_iam_policy_attachment" "object" {
   for_each   = aws_iam_policy.object
   name       = "${local.prefix}-permissions-on-s3-${each.key}"
-  roles      = module.eks.worker_iam_role_names
+  roles      = concat(module.eks.worker_iam_role_names, [module.aws_service_account.service_account_iam_role_name])
   policy_arn = each.value.arn
 }
 


### PR DESCRIPTION
# Motivation

S3 output was not passed to armonik, and the read/write permissions on the bucket were not given to the right role.

# Description

Propagate the S3 module output to armonik.
Give the permission to the role that is bound to the kubernetes service account given to core.

# Testing

Deploying with S3 and SQS is working as expected. It even works updating a deployment from Redis to S3.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.