### PR TITLE
fix: Restrict Helm provider version

### DIFF
--- a/infrastructure/quick-deploy/aws/versions.tf
+++ b/infrastructure/quick-deploy/aws/versions.tf
@@ -20,6 +20,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.21.1"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17.0"
+    }
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = "~> 1.14.0"

--- a/infrastructure/quick-deploy/gcp/versions.tf
+++ b/infrastructure/quick-deploy/gcp/versions.tf
@@ -13,6 +13,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.21.1"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17.0"
+    }
   }
 }
-

--- a/infrastructure/quick-deploy/localhost/versions.tf
+++ b/infrastructure/quick-deploy/localhost/versions.tf
@@ -16,6 +16,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.21.1"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17.0"
+    }
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = "~> 1.14.0"


### PR DESCRIPTION
# Motivation

Helm provider has been updated to plugin framework, and removed blocks from provider configuration.
It appears that this new version is not yet stable enough: https://github.com/hashicorp/terraform-provider-helm/issues/1637


# Description

Restrict the helm provider version to `~> 2.17.0`

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.