### PR TITLE
fix: Add mapping on content in worker limits and requests

### DIFF
--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -519,14 +519,8 @@ variable "compute_plane" {
       image             = optional(string, "dockerhubaneo/armonik_pollingagent")
       tag               = optional(string)
       image_pull_policy = optional(string, "IfNotPresent")
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string)
-      }))
-      requests = optional(object({
-        cpu    = optional(string)
-        memory = optional(string)
-      }))
+      limits = optional(map(string))
+      requests = optional(map(string))
       conf = optional(any, [])
     })
     worker = list(object({
@@ -534,14 +528,8 @@ variable "compute_plane" {
       image             = string
       tag               = optional(string)
       image_pull_policy = optional(string, "IfNotPresent")
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string)
-      }))
-      requests = optional(object({
-        cpu    = optional(string)
-        memory = optional(string)
-      }))
+      limits = optional(map(string))
+      requests = optional(map(string))
       conf = optional(any, [])
     }))
     cache_config = optional(object({


### PR DESCRIPTION


# Motivation

In terraform, workers were only looking to cpu and memory values. In order to make Kubernetes detect GPUs, we had to use the nvidia.com/gpu parameter and a mapping on the content of limits and requests.

# Description

Change from only accepting cpu and memory to other kind of content.

# Testing

None.

# Impact

We may be able to use GPUs inside ArmoniK's workers.

# Additional Information

None

# Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] I have thoroughly tested my modifications and added tests when necessary.
- [X] Tests pass locally and in the CI.
- [X] I have assessed the performance impact of my modifications.