### PR TITLE
chore: Avoid calling shell multiple times in make

### DIFF
--- a/infrastructure/quick-deploy/aws/Makefile
+++ b/infrastructure/quick-deploy/aws/Makefile
@@ -1,4 +1,4 @@
-CURRENT_DIR:=$(shell pwd)
+CURRENT_DIR != pwd
 GENERATED_DIR=$(CURRENT_DIR)/generated
 INGRESS_CERTIFICATES_DIR=$(GENERATED_DIR)/certificates/ingress
 PARAMETERS_FILE?=parameters.tfvars
@@ -7,8 +7,10 @@ VERSIONS_FILE?=../../../versions.tfvars.json
 STATE_FILE=armonik-terraform.tfstate
 OUTPUT_FILE=$(GENERATED_DIR)/armonik-output.json
 MODULES_DIR=$(GENERATED_DIR)/infra-modules
-MODULES_SOURCE=$(shell cat $(VERSIONS_FILE) | jq -r '.armonik_images.infra[0]')
-MODULES_VERSION=$(shell cat $(VERSIONS_FILE) | jq -r '.armonik_versions.infra')
+MODULES_SOURCE_DEFAULT != jq -r '.armonik_images.infra[0]' $(VERSIONS_FILE)
+MODULES_VERSION_DEFAULT != jq -r '.armonik_versions.infra' $(VERSIONS_FILE)
+MODULES_SOURCE=$(MODULES_SOURCE_DEFAULT)
+MODULES_VERSION=$(MODULES_VERSION_DEFAULT)
 
 # Randomly generated string that is preserved across calls
 RANDOM_PREFIX != [ -e $(GENERATED_DIR)/.prefix ] || { mkdir -p $(GENERATED_DIR) && tr -dc a-z0-9 </dev/urandom | head -c 10 > $(GENERATED_DIR)/.prefix ; } && cat $(GENERATED_DIR)/.prefix

--- a/infrastructure/quick-deploy/gcp/Makefile
+++ b/infrastructure/quick-deploy/gcp/Makefile
@@ -1,4 +1,4 @@
-CURRENT_DIR:=$(shell pwd)
+CURRENT_DIR != pwd
 GENERATED_DIR=$(CURRENT_DIR)/generated
 INGRESS_CERTIFICATES_DIR=$(GENERATED_DIR)/certificates/ingress
 PARAMETERS_FILE?=parameters.tfvars
@@ -7,15 +7,18 @@ VERSIONS_FILE?=../../../versions.tfvars.json
 STATE_FILE=armonik-terraform.tfstate
 OUTPUT_FILE=$(GENERATED_DIR)/armonik-output.json
 MODULES_DIR=$(GENERATED_DIR)/infra-modules
-MODULES_SOURCE=$(shell cat $(VERSIONS_FILE) | jq -r '.armonik_images.infra[0]')
-MODULES_VERSION=$(shell cat $(VERSIONS_FILE) | jq -r '.armonik_versions.infra')
+MODULES_SOURCE_DEFAULT != jq -r '.armonik_images.infra[0]' $(VERSIONS_FILE)
+MODULES_VERSION_DEFAULT != jq -r '.armonik_versions.infra' $(VERSIONS_FILE)
+MODULES_SOURCE=$(MODULES_SOURCE_DEFAULT)
+MODULES_VERSION=$(MODULES_VERSION_DEFAULT)
 
 # Randomly generated string that is preserved across calls
 RANDOM_PREFIX != [ -e $(GENERATED_DIR)/.prefix ] || { mkdir -p $(GENERATED_DIR) && tr -dc a-z0-9 </dev/urandom | head -c 5 > $(GENERATED_DIR)/.prefix ; } && cat $(GENERATED_DIR)/.prefix
+PROJECT_ID_DEFAULT != gcloud config get-value project
 
 export TF_DATA_DIR?=$(GENERATED_DIR)
 export TF_PLUGIN_CACHE_DIR?=$(GENERATED_DIR)/terraform-plugins
-export PROJECT_ID?=$(shell gcloud config get-value project)
+export PROJECT_ID?=$(PROJECT_ID_DEFAULT)
 export REGION?=europe-west1
 export NAMESPACE?=armonik
 export PREFIX?=armonik-$(RANDOM_PREFIX)
@@ -25,7 +28,6 @@ export TF_VAR_region?=$(REGION)
 export TF_VAR_namespace?=$(NAMESPACE)
 export TF_VAR_prefix?=$(PREFIX)
 export TF_VAR_project?=$(PROJECT_ID)
-SHELL:=/bin/bash
 
 .PHONY: apply destroy
 

--- a/infrastructure/quick-deploy/localhost/Makefile
+++ b/infrastructure/quick-deploy/localhost/Makefile
@@ -1,4 +1,4 @@
-CURRENT_DIR:=$(shell pwd)
+CURRENT_DIR != pwd
 GENERATED_DIR=$(CURRENT_DIR)/generated
 INGRESS_CERTIFICATES_DIR=$(GENERATED_DIR)/certificates/ingress
 PARAMETERS_FILE?=parameters.tfvars
@@ -6,8 +6,10 @@ EXTRA_PARAMETERS_FILE?=../../../extra.tfvars.json
 VERSIONS_FILE?=../../../versions.tfvars.json
 OUTPUT_FILE=$(GENERATED_DIR)/armonik-output.json
 MODULES_DIR=$(GENERATED_DIR)/infra-modules
-MODULES_SOURCE=$(shell cat $(VERSIONS_FILE) | jq -r '.armonik_images.infra[0]')
-MODULES_VERSION=$(shell cat $(VERSIONS_FILE) | jq -r '.armonik_versions.infra')
+MODULES_SOURCE_DEFAULT != jq -r '.armonik_images.infra[0]' $(VERSIONS_FILE)
+MODULES_VERSION_DEFAULT != jq -r '.armonik_versions.infra' $(VERSIONS_FILE)
+MODULES_SOURCE=$(MODULES_SOURCE_DEFAULT)
+MODULES_VERSION=$(MODULES_VERSION_DEFAULT)
 
 export KUBE_CONFIG_PATH?=$(HOME)/.kube/config
 export TF_DATA_DIR?=$(GENERATED_DIR)


### PR DESCRIPTION
# Motivation

Shell expansion in make are done every time a variable is called, making it slow for gcp deployment where a gcloud command is called every time the project is needed.

# Description

All shell commands in variables have been changed to be eagerly evaluated instead of lazily.

# Testing

Make commands work locally, and are faster (especially  gcp, where make get-modules went from 1.7s to 1s).

# Impact

Behavior of make is the same.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.