### PR TITLE
chore: make sure k3s installer stript copies kubeconfig

### DIFF
--- a/infrastructure/utils/scripts/installation/prerequisites/install-k3s.sh
+++ b/infrastructure/utils/scripts/installation/prerequisites/install-k3s.sh
@@ -1,7 +1,24 @@
 #! /bin/sh
 # This script is used to install k3s.
 
-curl -sfL https://get.k3s.io |sh -s - --write-kubeconfig-mode 644 --docker --write-kubeconfig ~/.kube/config --kubelet-arg cgroup-driver=systemd
+K3S_DEFAULT_KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+TARGET_KUBECONFIG=$HOME/.kube/config
+
+set -ex
+curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644 --docker --write-kubeconfig $TARGET_KUBECONFIG --kubelet-arg cgroup-driver=systemd
+
+# Ensure that the target kubecondig gets properly updated after each installation
+mkdir -p $HOME/.kube
+if [ -f $K3S_DEFAULT_KUBECONFIG ]; then
+  # Copy default config to the target config only if the first one
+  # is newer than the target or if the target config does not exist
+  sudo cp -u $K3S_DEFAULT_KUBECONFIG $TARGET_KUBECONFIG
+  sudo chmod 644 $TARGET_KUBECONFIG
+else
+  echo "Error: Default kubeconfig not found at $K3S_DEFAULT_KUBECONFIG."
+  echo "Either it has not been created or its default location has changed. Check the k3s documentation"
+  exit 1
+fi
 
 # To uninstall
 # sudo /usr/local/bin/k3s-uninstall.sh


### PR DESCRIPTION
# Motivation

Make `k3s` installation script more robust. 

# Description

In some settings (wsl2 + ubuntu + zsh), the  [custom `k3s` installation script](https://github.com/aneoconsulting/ArmoniK/blob/main/infrastructure/utils/scripts/installation/prerequisites/install-k3s.sh) , fails to copy the generated kubeconfig to the requested location (`./kube/config`).  The PR enlarges the script to handle this situation.

# Testing

Test locally that install script works as expected.

# Impact

Less errors when installing k3s

# Additional Information


# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [] I have assessed the performance impact of my modifications.