### PR TITLE
chore: Allow empty MODULES_VERSION

### DIFF
--- a/.docs/content/getting-started/installation/kubernetes.md
+++ b/.docs/content/getting-started/installation/kubernetes.md
@@ -48,6 +48,22 @@ You can specify a custom parameter file. When executing the `make` command, you 
 make PARAMETERS_FILE=my-custom-parameters.tfvars
 ```
 
+## Custom infrastructure version
+
+If you need to fetch a specific version of the infrastructure, you can set the `MODULES_VERSION` parameter with the tag or branch you want to use.
+
+
+```bash
+# Fetch the main branch of the infrastructure and deploy
+make MODULES_VERSION=main deploy
+```
+If `MODULES_VERSION` is empty, the current version of the infra folder will be used (`generated/infra-modules`).
+
+```bash
+# Deploy without fetching any specific tag or branch
+make MODULES_VERSION= deploy
+```
+
 ## Destroy
 
 To destroy the deployment, type:
@@ -55,4 +71,3 @@ To destroy the deployment, type:
 ```bash
 make destroy
 ```
-

--- a/infrastructure/quick-deploy/aws/Makefile
+++ b/infrastructure/quick-deploy/aws/Makefile
@@ -9,8 +9,8 @@ OUTPUT_FILE=$(GENERATED_DIR)/armonik-output.json
 MODULES_DIR=$(GENERATED_DIR)/infra-modules
 MODULES_SOURCE_DEFAULT != jq -r '.armonik_images.infra[0]' $(VERSIONS_FILE)
 MODULES_VERSION_DEFAULT != jq -r '.armonik_versions.infra' $(VERSIONS_FILE)
-MODULES_SOURCE=$(MODULES_SOURCE_DEFAULT)
-MODULES_VERSION=$(MODULES_VERSION_DEFAULT)
+MODULES_SOURCE?=$(MODULES_SOURCE_DEFAULT)
+MODULES_VERSION?=$(MODULES_VERSION_DEFAULT)
 
 # Randomly generated string that is preserved across calls
 RANDOM_PREFIX != [ -e $(GENERATED_DIR)/.prefix ] || { mkdir -p $(GENERATED_DIR) && tr -dc a-z0-9 </dev/urandom | head -c 10 > $(GENERATED_DIR)/.prefix ; } && cat $(GENERATED_DIR)/.prefix
@@ -110,12 +110,20 @@ cliconfig:
 	@echo "export AKCONFIG=$(GENERATED_DIR)/armonik-cli.yaml"
 
 get-modules:
-	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) ||\
-		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ;\
-		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
+	@if [ -d $(MODULES_DIR) ]; then \
+		if [ -n "$(MODULES_VERSION)" ]; then \
+			git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) || \
+			git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ; \
+			git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+		fi \
 	else \
-		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
+		if [ -n "$(MODULES_VERSION)" ]; then \
+			git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR); \
+			git -C $(MODULES_DIR) config --replace-all remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" ; \
+		else \
+			echo "MODULES_DIR does not exist and MODULES_VERSION is empty" >&2; \
+			exit 1; \
+		fi \
 	fi
 
 clean:

--- a/infrastructure/quick-deploy/gcp/Makefile
+++ b/infrastructure/quick-deploy/gcp/Makefile
@@ -9,8 +9,8 @@ OUTPUT_FILE=$(GENERATED_DIR)/armonik-output.json
 MODULES_DIR=$(GENERATED_DIR)/infra-modules
 MODULES_SOURCE_DEFAULT != jq -r '.armonik_images.infra[0]' $(VERSIONS_FILE)
 MODULES_VERSION_DEFAULT != jq -r '.armonik_versions.infra' $(VERSIONS_FILE)
-MODULES_SOURCE=$(MODULES_SOURCE_DEFAULT)
-MODULES_VERSION=$(MODULES_VERSION_DEFAULT)
+MODULES_SOURCE?=$(MODULES_SOURCE_DEFAULT)
+MODULES_VERSION?=$(MODULES_VERSION_DEFAULT)
 
 # Randomly generated string that is preserved across calls
 RANDOM_PREFIX != [ -e $(GENERATED_DIR)/.prefix ] || { mkdir -p $(GENERATED_DIR) && tr -dc a-z0-9 </dev/urandom | head -c 5 > $(GENERATED_DIR)/.prefix ; } && cat $(GENERATED_DIR)/.prefix
@@ -110,12 +110,20 @@ cliconfig:
 	@echo "export AKCONFIG=$(GENERATED_DIR)/armonik-cli.yaml"
 
 get-modules:
-	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) ||\
-		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ;\
-		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
+	@if [ -d $(MODULES_DIR) ]; then \
+		if [ -n "$(MODULES_VERSION)" ]; then \
+			git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) || \
+			git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ; \
+			git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+		fi \
 	else \
-		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
+		if [ -n "$(MODULES_VERSION)" ]; then \
+			git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR); \
+			git -C $(MODULES_DIR) config --replace-all remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" ; \
+		else \
+			echo "MODULES_DIR does not exist and MODULES_VERSION is empty" >&2; \
+			exit 1; \
+		fi \
 	fi
 
 clean:

--- a/infrastructure/quick-deploy/localhost/Makefile
+++ b/infrastructure/quick-deploy/localhost/Makefile
@@ -8,8 +8,8 @@ OUTPUT_FILE=$(GENERATED_DIR)/armonik-output.json
 MODULES_DIR=$(GENERATED_DIR)/infra-modules
 MODULES_SOURCE_DEFAULT != jq -r '.armonik_images.infra[0]' $(VERSIONS_FILE)
 MODULES_VERSION_DEFAULT != jq -r '.armonik_versions.infra' $(VERSIONS_FILE)
-MODULES_SOURCE=$(MODULES_SOURCE_DEFAULT)
-MODULES_VERSION=$(MODULES_VERSION_DEFAULT)
+MODULES_SOURCE?=$(MODULES_SOURCE_DEFAULT)
+MODULES_VERSION?=$(MODULES_VERSION_DEFAULT)
 
 export KUBE_CONFIG_PATH?=$(HOME)/.kube/config
 export TF_DATA_DIR?=$(GENERATED_DIR)
@@ -64,12 +64,20 @@ output:
 	@echo "\nOUTPUT FILE: $(OUTPUT_FILE)"
 
 get-modules:
-	@if [ -d $(MODULES_DIR) ]; then\
-		git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) ||\
-		git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ;\
-		git -C $(MODULES_DIR) -c advice.detachedHead=false checkout $(MODULES_VERSION);\
+	@if [ -d $(MODULES_DIR) ]; then \
+		if [ -n "$(MODULES_VERSION)" ]; then \
+			git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) || \
+			git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ; \
+			git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+		fi \
 	else \
-		git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --no-single-branch --depth 1 $(MODULES_SOURCE) $(MODULES_DIR);\
+		if [ -n "$(MODULES_VERSION)" ]; then \
+			git -c advice.detachedHead=false clone --branch $(MODULES_VERSION) --depth 1 $(MODULES_SOURCE) $(MODULES_DIR); \
+			git -C $(MODULES_DIR) config --replace-all remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" ; \
+		else \
+			echo "MODULES_DIR does not exist and MODULES_VERSION is empty" >&2; \
+			exit 1; \
+		fi \
 	fi
 
 clean:


### PR DESCRIPTION
# Motivation

When working on custom infra, it can be interesting to disable the fetching of the infra modules, and thus keep extra commits that have been added to ArmoniK.Infra

# Description

If MODULES_VERSION is empty, skip fetching of the modules. If the folder MODULES_DIR does not exit and MODULES_VERSION is empty, an error is raised.
Also force the clone of a single branch, but reenable fetching other branches later on.

# Testing

All the combination of make get-modules sequence have been tested and works as expected.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.