### PR TITLE
chore(deps): Change ActiveMQ image to Apache registry

### DIFF
--- a/infrastructure/quick-deploy/aws/variables.tf
+++ b/infrastructure/quick-deploy/aws/variables.tf
@@ -329,7 +329,7 @@ variable "mq_credentials" {
 variable "activemq" {
   description = "Parameters of ActiveMQ"
   type = object({
-    image_name         = optional(string, "symptoma/activemq")
+    image_name         = optional(string, "apache/activemq-classic")
     image_tag          = optional(string)
     node_selector      = optional(any, {})
     image_pull_secrets = optional(string, "")

--- a/infrastructure/quick-deploy/gcp/variables.tf
+++ b/infrastructure/quick-deploy/gcp/variables.tf
@@ -597,7 +597,7 @@ variable "static" {
 variable "activemq" {
   description = "Parameters of ActiveMQ"
   type = object({
-    image_name         = optional(string, "symptoma/activemq")
+    image_name         = optional(string, "apache/activemq-classic")
     image_tag          = optional(string)
     node_selector      = optional(any, {})
     image_pull_secrets = optional(string, "")

--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -110,7 +110,7 @@ variable "shared_storage" {
 variable "activemq" {
   description = "Parameters of ActiveMQ"
   type = object({
-    image_name         = optional(string, "symptoma/activemq")
+    image_name         = optional(string, "apache/activemq-classic")
     image_tag          = optional(string)
     node_selector      = optional(any, {})
     image_pull_secrets = optional(string, "")

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,7 +1,7 @@
 {
   "armonik_versions": {
     "armonik":       "2.22.0",
-    "infra":         "0.12.3",
+    "infra":         "0.12.4",
     "infra_plugins": "0.1.1",
     "core":          "0.34.0",
     "api":           "3.26.0",
@@ -57,7 +57,7 @@
     "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe":         "v2.15.0-eks-1-32-14",
     "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar": "v2.13.0-eks-1-32-14",
     "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner":  "v5.2.0-eks-1-32-14",
-    "symptoma/activemq":                                              "5.18.6",
+    "apache/activemq-classic":                                        "6.1.7",
     "mongo":                                                          "8.0.10",
     "bitnami/mongodb":                                                "8.0.10-debian-12-r1",
     "bitnami/mongodb-sharded":                                        "8.0.10-debian-12-r1",


### PR DESCRIPTION
# Motivation

ActiveMQ image from symptoma is outdated and has vulnerabilities, meanwhile Apache now publishes official ActiveMQ images.

# Description

- Change image to target apache/activemq-classic:6.1.7
- Change infra to 0.12.4 that is compatible with activemq-classic

# Testing

Localhost deployment with both symptoma/activemq:5.18.6 and apache/activemq-classic:6.1.7 work as expected without any modification.

# Impact

This makes it possible to use official Apache images while retaining compatibility with previous symptoma images.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.