### PR TITLE
chore(deps): Update Infra to 0.13.0 and use bitnamilegacy images

### DIFF
--- a/infrastructure/quick-deploy/aws/ecr.tf
+++ b/infrastructure/quick-deploy/aws/ecr.tf
@@ -1,5 +1,5 @@
 locals {
-  mongodb_image_name = try(coalesce(var.mongodb.image_name), var.mongodb_sharding != null ? "bitnami/mongodb-sharded" : "bitnami/mongodb")
+  mongodb_image_name = try(coalesce(var.mongodb.image_name), var.mongodb_sharding != null ? "bitnamilegacy/mongodb-sharded" : "bitnamilegacy/mongodb")
   ecr_input_images = concat([
     [var.eks.docker_images.cluster_autoscaler.image, var.eks.docker_images.cluster_autoscaler.tag],
     [var.eks.docker_images.instance_refresh.image, var.eks.docker_images.instance_refresh.tag],

--- a/infrastructure/quick-deploy/gcp/gar.tf
+++ b/infrastructure/quick-deploy/gcp/gar.tf
@@ -1,5 +1,5 @@
 locals {
-  mongodb_image_name = can(coalesce(var.mongodb_sharding)) ? coalesce(var.mongodb.image_name, "bitnami/mongodb-sharded") : coalesce(var.mongodb.image_name, "bitnami/mongodb")
+  mongodb_image_name = can(coalesce(var.mongodb_sharding)) ? coalesce(var.mongodb.image_name, "bitnamilegacy/mongodb-sharded") : coalesce(var.mongodb.image_name, "bitnamilegacy/mongodb")
   default_tags       = module.default_images.image_tags
   input_docker_images = concat([
     var.keda != null ? [var.keda.image_name, var.keda.image_tag] : null,

--- a/infrastructure/quick-deploy/localhost/storage.tf
+++ b/infrastructure/quick-deploy/localhost/storage.tf
@@ -31,7 +31,7 @@ module "mongodb" {
   namespace = local.namespace
   mongodb = {
     image                 = var.mongodb.image_name
-    tag                   = try(coalesce(var.mongodb.image_tag), local.default_tags[coalesce(var.mongodb.image_name, "bitnami/mongodb")])
+    tag                   = try(coalesce(var.mongodb.image_tag), local.default_tags[coalesce(var.mongodb.image_name, "bitnamilegacy/mongodb")])
     node_selector         = var.mongodb.node_selector
     image_pull_secrets    = var.mongodb.image_pull_secrets
     replicas              = var.mongodb.replicas
@@ -50,7 +50,7 @@ module "mongodb_sharded" {
 
   mongodb = {
     image                 = var.mongodb.image_name
-    tag                   = try(coalesce(var.mongodb.image_tag), local.default_tags[coalesce(var.mongodb.image_name, "bitnami/mongodb-sharded")])
+    tag                   = try(coalesce(var.mongodb.image_tag), local.default_tags[coalesce(var.mongodb.image_name, "bitnamilegacy/mongodb-sharded")])
     node_selector         = var.mongodb.node_selector
     image_pull_secrets    = var.mongodb.image_pull_secrets
     helm_chart_repository = try(coalesce(var.mongodb.helm_chart_repository), var.helm_charts["mongodb-sharded"].repository)

--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -131,7 +131,7 @@ variable "activemq" {
 variable "rabbitmq" {
   description = "Parameters of RabbitMQ"
   type = object({
-    image                 = optional(string, "bitnami/rabbitmq")
+    image                 = optional(string, "bitnamilegacy/rabbitmq")
     tag                   = optional(string)
     helm_chart_repository = optional(string)
     helm_chart_version    = optional(string)

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,7 +1,7 @@
 {
   "armonik_versions": {
     "armonik":       "2.22.1",
-    "infra":         "0.12.3",
+    "infra":         "0.13.0",
     "infra_plugins": "0.1.1",
     "core":          "0.34.1",
     "api":           "3.27.0",
@@ -59,8 +59,8 @@
     "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner":  "v5.2.0-eks-1-32-14",
     "symptoma/activemq":                                              "5.18.6",
     "mongo":                                                          "8.0.10",
-    "bitnami/mongodb":                                                "8.0.10-debian-12-r1",
-    "bitnami/mongodb-sharded":                                        "8.0.10-debian-12-r1",
+    "bitnamilegacy/mongodb":                                          "8.0.13-debian-12-r0",
+    "bitnamilegacy/mongodb-sharded":                                  "8.0.13-debian-12-r0",
     "rtsp/mongosh":                                                   "2.5.2",
     "redis":                                                          "8.0.2-alpine",
     "minio/minio":                                                    "RELEASE.2025-05-24T17-08-30Z",
@@ -72,7 +72,7 @@
     "fluent/fluent-bit":                                              "4.0.3",
     "nginxinc/nginx-unprivileged":                                    "1.27.5-alpine-slim",
     "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner":    "v4.0.18",
-    "bitnami/rabbitmq":                                               "4.1.1",
+    "bitnamilegacy/rabbitmq":                                         "4.1.3",
     "ghcr.io/chaos-mesh/chaos-mesh":                                  "v2.7.2",
     "ghcr.io/chaos-mesh/chaos-daemon":                                "v2.7.2",
     "ghcr.io/chaos-mesh/chaos-dashboard":                             "v2.7.2",


### PR DESCRIPTION
# Motivation

Bitnami has been bought by Broadcom. Consequently, their open-source policy has changed, and only their latest images will be available for free: https://github.com/bitnami/charts#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog

# Description

Update infra to 0.13.0 to force bitnami legacy images, and change default images to bitnami legacy.

# Testing

Deployment is working with only bitnamilegacy images.

# Impact

After August, the 28th, this patch will be required to deploy ArmoniK.

# Additional Information

Long term solution would be to drop bitnami charts altogether.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.