### PR TITLE
fix: Add support for infra branch in versions.tfvars.json

### DIFF
--- a/infrastructure/quick-deploy/aws/Makefile
+++ b/infrastructure/quick-deploy/aws/Makefile
@@ -112,9 +112,16 @@ cliconfig:
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then \
 		if [ -n "$(MODULES_VERSION)" ]; then \
-			git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) || \
-			git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ; \
-			git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+			if [ "$$(git -C $(MODULES_DIR) rev-parse --is-shallow-repository)" = true ]; then \
+				SHALLOW=1; \
+			fi; \
+			if git -C $(MODULES_DIR) fetch $${SHALLOW:+--depth 1} origin tag $(MODULES_VERSION); then \
+				git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+			else \
+				git -C $(MODULES_DIR) fetch $${SHALLOW:+--depth 1} origin $(MODULES_VERSION) ; \
+				git -C $(MODULES_DIR) switch $(MODULES_VERSION); \
+				[ "$${SHALLOW:-0}" = 0 ] || echo "Warning: Repository is shallow and can lead to split history if you add commits to the infra branch.\nUse the following command to unshallow the repository if needed:\ngit -C $(MODULES_DIR) fetch --unshallow"; \
+			fi \
 		fi \
 	else \
 		if [ -n "$(MODULES_VERSION)" ]; then \

--- a/infrastructure/quick-deploy/gcp/Makefile
+++ b/infrastructure/quick-deploy/gcp/Makefile
@@ -112,9 +112,16 @@ cliconfig:
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then \
 		if [ -n "$(MODULES_VERSION)" ]; then \
-			git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) || \
-			git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ; \
-			git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+			if [ "$$(git -C $(MODULES_DIR) rev-parse --is-shallow-repository)" = true ]; then \
+				SHALLOW=1; \
+			fi; \
+			if git -C $(MODULES_DIR) fetch $${SHALLOW:+--depth 1} origin tag $(MODULES_VERSION); then \
+				git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+			else \
+				git -C $(MODULES_DIR) fetch $${SHALLOW:+--depth 1} origin $(MODULES_VERSION) ; \
+				git -C $(MODULES_DIR) switch $(MODULES_VERSION); \
+				[ "$${SHALLOW:-0}" = 0 ] || echo "Warning: Repository is shallow and can lead to split history if you add commits to the infra branch.\nUse the following command to unshallow the repository if needed:\ngit -C $(MODULES_DIR) fetch --unshallow"; \
+			fi \
 		fi \
 	else \
 		if [ -n "$(MODULES_VERSION)" ]; then \

--- a/infrastructure/quick-deploy/localhost/Makefile
+++ b/infrastructure/quick-deploy/localhost/Makefile
@@ -66,9 +66,16 @@ output:
 get-modules:
 	@if [ -d $(MODULES_DIR) ]; then \
 		if [ -n "$(MODULES_VERSION)" ]; then \
-			git -C $(MODULES_DIR) fetch --depth 1 origin tag $(MODULES_VERSION) || \
-			git -C $(MODULES_DIR) fetch --depth 1 origin $(MODULES_VERSION) ; \
-			git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+			if [ "$$(git -C $(MODULES_DIR) rev-parse --is-shallow-repository)" = true ]; then \
+				SHALLOW=1; \
+			fi; \
+			if git -C $(MODULES_DIR) fetch $${SHALLOW:+--depth 1} origin tag $(MODULES_VERSION); then \
+				git -C $(MODULES_DIR) -c advice.detachedHead=false switch -d $(MODULES_VERSION); \
+			else \
+				git -C $(MODULES_DIR) fetch $${SHALLOW:+--depth 1} origin $(MODULES_VERSION) ; \
+				git -C $(MODULES_DIR) switch $(MODULES_VERSION); \
+				[ "$${SHALLOW:-0}" = 0 ] || echo "Warning: Repository is shallow and can lead to split history if you add commits to the infra branch.\nUse the following command to unshallow the repository if needed:\ngit -C $(MODULES_DIR) fetch --unshallow"; \
+			fi \
 		fi \
 	else \
 		if [ -n "$(MODULES_VERSION)" ]; then \


### PR DESCRIPTION
# Motivation

When getting the infra modules from makefile, git switch generates an error if the `MODULES_VERSION` value is a branch instead of a tag, because detached switch requires to specify the remote.

# Description

If we detected that `MODULES_VERSION` targets a branch, we use regular `git switch` instead of `git switch -d`.
`make get-modules` now also keeps the shallow-ness of the repo to avoid errors when committing directly from `generated/infra-modules`

# Testing

- `make get-modules MODULES_VERSION=0.13.0` with an empty  `generated/infra-modules`: OK, shallow
- `make get-modules MODULES_VERSION=main` with an empty  `generated/infra-modules`: OK, shallow
- `make get-modules MODULES_VERSION=0.13.0` with a shallow  `generated/infra-modules`: OK, shallow
- `make get-modules MODULES_VERSION=main` with a shallow  `generated/infra-modules`: OK, shallow + warning
- `make get-modules MODULES_VERSION=0.13.0` with a "deep" `generated/infra-modules`: OK, "deep"
- `make get-modules MODULES_VERSION=main` with a "deep" `generated/infra-modules`: OK, "deep"

# Impact

This change should limit the number of errors while working on the infra.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.