### PR TITLE
docs: add few missing point in gcp doc

### DIFF
--- a/.docs/content/getting-started/installation/gcp.md
+++ b/.docs/content/getting-started/installation/gcp.md
@@ -21,6 +21,12 @@ You can authenticate using the following command:
 gcloud auth login
 ```
 
+then :
+
+```bash
+gcloud auth application-default login
+```
+
 To configure the project, if you don't know the project ID, you can list all the projects using the following command:
 
 ```bash
@@ -70,6 +76,8 @@ make destroy PREFIX=<PREFIX_KEY>
 ```
 
 #### 2. Destroy the GCP Prefix Key - In case you don't need to deploy on GCP anymore
+
+:warning: In case you ALREADY HAVE DESTROYED and you don't need to deploy on GCP anymore :warning:
 
 It's an optional step if you are not willing to use the prefix key in the future. However, please note that if you delete the prefix key and the terraform state from the GCP environment, you will not be able to reproduce this exact deployment on GCP. It is not recommended to perform this step unless you are certain that you will not need the prefix key again, such as when you are leaving the project.
 


### PR DESCRIPTION
# Motivation

The deployment tutorial for GCP was missing a command, which could lead to confusion or failed deployments when following the documentation. Additionally, important warnings were not clearly highlighted, making it harder for users to identify potential pitfalls.

# Description

* Added the missing deployment command in the GCP documentation tutorial.
* Inserted `:warning:` markers in relevant sections to highlight important caveats and prevent common mistakes.

# Testing

* Verified the updated GCP deployment instructions end-to-end to ensure the missing command is required and works as intended.
* Checked that the added `:warning:` markers render properly in the documentation.

# Impact

* Helps users avoid errors when deploying on GCP by making the tutorial more explicit and readable.