### PR TITLE
fix: use username as prefix is valid now

### DIFF
--- a/infrastructure/quick-deploy/gcp/common.tf
+++ b/infrastructure/quick-deploy/gcp/common.tf
@@ -49,5 +49,5 @@ locals {
     "creation_date"      = "date-${null_resource.timestamp.triggers["date"]}"
   }, var.labels)
   node_pools_labels = { for key, value in var.gke.node_pools_labels : key => merge(local.labels, value) }
-  node_pools_tags   = { for node_pool in coalesce(var.gke.node_pools, []) : node_pool["name"] => values(local.labels) }
+  node_pools_tags   = { for node_pool in coalesce(var.gke.node_pools, []) : node_pool["name"] => toset(values(local.labels)) }
 }


### PR DESCRIPTION
# Motivation

When using my username as a prefix for the GCP ArmoniK deployment, I encountered a duplicate error, as if the prefix already existed.

# Description

Added a `toset` to avoid duplicate errors when applying a username as a prefix.

# Testing

Tested by deploying with my username as a prefix — deployment succeeded without errors.

# Impact

Users can now safely use their username as a prefix for GCP ArmoniK deployments.
