### PR TITLE
fix: use official helm installer script

### DIFF
--- a/tools/installation/prerequisites/install-helm.sh
+++ b/tools/installation/prerequisites/install-helm.sh
@@ -1,12 +1,10 @@
 #! /bin/sh
 # This script is used to install helm.
 
-curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
-
-sudo apt install -y apt-transport-https
-
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-
-sudo apt update
-
-sudo apt install -y helm
+if command -v helm &> /dev/null; then
+    echo "Helm is already installed."
+    helm version
+else
+    echo "Installing Helm..."
+    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+fi


### PR DESCRIPTION
# Motivation

Helm host for the `deb` have changed so the current script does not work. This PR updates it to use the official install script

# Description

# Testing

# Impact

Prerequisites installer should work out of the box

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.