### PR TITLE
docs: Add clarification on the Fingerprint field in Auth config

### DIFF
--- a/.docs/content/user-guide/how-to-configure-authentication.md
+++ b/.docs/content/user-guide/how-to-configure-authentication.md
@@ -137,7 +137,7 @@ The JSON authentication configuration file must have the following format (note 
   - The ```Fingerprint``` field represents the SHA-1 hash of the certificate's raw binary data, which can be extracted using the following command
 
     ```bash
-      openssl x509 -in </path/to/certificate.crt> -outform DER | sha1sum | awk '{print $1}'
+      openssl x509 -in </path/to/certificate.crt> -noout -fingerprint | sed 's/.*=\|://g' | tr A-F a-f
     ```
 
   - If ```Fingerprint``` is null, the user will be authenticated using ANY certificate with the given Common Name.


### PR DESCRIPTION
# Motivation

`Fingerprint` field in the JSON authentication configuration file is not clearly documented. 

# Description

When deploying ArmoniK with a self generated certificated, using the generated certificate SHA1 fingerprint as  `Fingerprint` field in the JSON authentication configuration file does not work as expected.  The documentation is not clear in this point, as it suggest to use the SHA1 fingerprint of the certificate,  when looking at  the [tls terraform provider](https://github.com/hashicorp/terraform-provider-tls/blob/4a6ab5c7d27a4265fc6ddeecc6aba6e95ae7a75c/internal/provider/data_source_certificate.go#L287), is noted that the correct value to use is the using the SHA-1 hash of the certificate's raw binary data instead.

# Testing

Tested a deployment with a self generated certificate and using the SHA-1 hash of the certificate's raw binary data to populate the 
`Fingerprint` field in the JSON authentication configuration works as expected. 

# Impact



# Additional Information


# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.