### PR TITLE
chore: poc sso

### DIFF
--- a/infrastructure/quick-deploy/localhost/armonik.tf
+++ b/infrastructure/quick-deploy/localhost/armonik.tf
@@ -60,6 +60,8 @@ module "armonik" {
   environment_description = var.environment_description
   static                  = var.static
 
+  oauth_configuration = var.oauth_configuration
+
   #metrics_exporter
   metrics_exporter = {
     image              = var.metrics_exporter.image_name

--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -669,3 +669,14 @@ variable "static" {
   type        = any
   default     = {}
 }
+
+variable "oauth_configuration" {
+  type = object({
+    provider_root_URI               = string
+    provider_user_info_endpoint     = string
+    provider_authorization_endpoint = string
+    client_id                       = string
+    response_type                   = optional(string, "refresh_token")
+  })
+  default = null
+}


### PR DESCRIPTION
# Motivation

ArmoniK team wanted to know if it was feasible to connect a sso to armonik.

# Description
Using the [ngx_http_auth_request_module](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html) nginx module, the goal is to recreate the flow described in this [openid documentation](https://openid.net/specs/openid-connect-core-1_0.html#Overview).

A variable has been added, named `oauth_configuration`, with the following content:
- `provider_root_URI` : Address of the sso service.
- `provider_user_info_endpoint` : Endpoint of the sso service that checks user claims and data (generally `userinfo`).
- `provider_authorization_endpoint` : Endpoint of the sso service that logs the user and return the associated token or code to the client.
- `client_id` : Id of the client registered to the sso service (Represent one endpoint of the client with the oidc mock provider).
- `response_type` : represents the way the client awaits the sso service to return user information. Can be a code, a token...

Added two location in the ingress configmap :
- `/auth` : use a proxy_pass method to get the claims associated to the user. If the user is not connected, can return either 401 or 403 http errors.
- `authError`: location used when the `/auth` fails. Make the user connect and return either a **code**, **refresh_token**, **access_token**... [click here for more information](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html)

# Testing

First, use the branch `chore/poc-sso` for the infra.

Testing locally can be done using [openId Mock Provider](https://oidc-provider-mock.readthedocs.io/stable/index.html). Just use the command:
```sh
pipx run oidc-provider-mock --host 0.0.0.0
```
To create an instance of an oidc mock provider. It is also available as a docker image.

Next step is to register a valid endpoint and getting a ClientID, by using the command:
```sh
curl -XPOST localhost:9400/oauth2/clients \
   --json '{"redirect_uris": ["http://${your_armonik_host}:${your_armonik_port}/admin/en/"]}'
```

And use the returned client ID in the `oauth_configuration` variable. In the end, your variable in parameters.tfvars should look like this:
```hashicorp
oauth_configuration = {
  provider_root_URI               = "http://172.26.174.64:9400"
  provider_user_info_endpoint     = "/userinfo"
  provider_authorization_endpoint = "/oauth2/authorize"
  client_id                       = "37c9cadc-2ada-42ab-8c54-872177ac38ba"
  response_type                   = "code" # Response type is code because the mock service only accept this.
}
```

This is kinda painfull to know if it is working, since nginx cannot provide the access_token required by the `userinfo` endpoint (since only a code can be returned by the service...). From experience, you should not have any nginx error, but you should loop on the /authorize page of the mock service.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.