### PR TITLE
chore: update internal dependencies

### DIFF
--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -3,11 +3,11 @@
     "armonik":       "2.23.0",
     "infra":         "0.15.1",
     "infra_plugins": "0.3.0",
-    "core":          "0.37.0",
+    "core":          "0.37.2",
     "api":           "3.28.3",
     "gui":           "0.15.1",
-    "extcsharp":     "0.21.0",
-    "extcpp":        "0.4.2",
+    "extcsharp":     "0.21.2",
+    "extcpp":        "0.4.4",
     "extjava":       "0.1.2",
     "samples":       "2.23.0"
   },
@@ -24,7 +24,6 @@
     "core": [
       "dockerhubaneo/armonik_pollingagent",
       "dockerhubaneo/armonik_control_metrics",
-      "dockerhubaneo/armonik_control_partition_metrics",
       "dockerhubaneo/armonik_control",
       "dockerhubaneo/armonik_core_stream_test_worker",
       "dockerhubaneo/armonik_core_stream_test_client",


### PR DESCRIPTION
# Motivation

Update internal ArmoniK component versions to their latest patch releases and remove an obsolete image reference.

# Description

Bumps the following component versions in `versions.tfvars.json`:

- `core`: `0.37.0` → `0.37.2`
- `extcsharp`: `0.21.0` → `0.21.2`
- `extcpp`: `0.4.2` → `0.4.4`

Also removes `dockerhubaneo/armonik_control_partition_metrics` from the list of core Docker images, as it is no longer shipped as a separate image in the updated core release.
