### PR TITLE
fix: Make merge compatible with a null persistency parameter

### DIFF
--- a/infrastructure/quick-deploy/aws/storage.tf
+++ b/infrastructure/quick-deploy/aws/storage.tf
@@ -424,7 +424,7 @@ locals {
   ) : {}
 
   # Final merged parameters: defaults + user overrides
-  mongodb_shards_parameters    = merge(local.ebs_shards_defaults, local.efs_shards_defaults, var.mongodb.persistence.shards.parameters)
-  mongodb_configsvr_parameters = merge(local.ebs_configsvr_defaults, local.efs_configsvr_defaults, var.mongodb.persistence.configsvr.parameters)
+  mongodb_shards_parameters    = merge(local.ebs_shards_defaults, local.efs_shards_defaults, var.mongodb.persistence != null ? var.mongodb.persistence.shards.parameters : {})
+  mongodb_configsvr_parameters = merge(local.ebs_configsvr_defaults, local.efs_configsvr_defaults, var.mongodb.persistence != null ? var.mongodb.persistence.configsvr.parameters : {})
 
 }


### PR DESCRIPTION
# Motivation

Use of percona operator (https://github.com/aneoconsulting/ArmoniK/pull/1439) introduced a regression were it not possible anymore to deploy on AWS without persistence. This is due to a local that does not handle null values properly.

This regression made the AWS benchmark fail.

# Description

Add a check on null when computing locals `mongodb_shards_parameters` and `mongodb_configsvr_parameters`.

# Testing

Benchmark on AWS still fails because of stock out, but plan now works: https://github.com/aneoconsulting/ArmoniK/actions/runs/22710506134/job/65847236764

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.