### PR TITLE
fix: AWS benchmarks unable to run

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -24,6 +24,10 @@ on:
         description: "Version of Extension Csharp to deploy"
         required: false
         default: ""
+      region:
+        description: "AWS region to deploy to"
+        required: false
+        default: "eu-west-3"
 
 jobs:
   deploy:
@@ -31,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       terraform-output: ${{ steps.deploy.outputs.terraform-output }}
+    env:
+      REGION: ${{ inputs.region }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -41,7 +47,7 @@ jobs:
           terraform: true
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: eu-west-3
+          AWS_REGION: ${{ inputs.region }}
       - if: ${{ inputs.bootstrap }}
         id: bootstrap-deploy
         name: Deploy Bootstrap
@@ -66,6 +72,7 @@ jobs:
     env:
       TERRAFORM_OUTPUT: ${{ needs.deploy.outputs.terraform-output }}
       KUBE_CONFIG: ${{ needs.deploy.outputs.kube-config }}
+      REGION: ${{ inputs.region }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -75,7 +82,7 @@ jobs:
           aws: true
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: eu-west-3
+          AWS_REGION: ${{ inputs.region }}
       - name: Terraform Output
         run: |
           echo "$TERRAFORM_OUTPUT"
@@ -90,6 +97,8 @@ jobs:
       - deploy
       - test
     if: "always()"
+    env:
+      REGION: ${{ inputs.region }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -100,7 +109,7 @@ jobs:
           terraform: true
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: eu-west-3
+          AWS_REGION: ${{ inputs.region }}
       - id: destroy
         name: Destroy deployment
         uses: aneoconsulting/ArmoniK.Action.Deploy/destroy@main

--- a/.github/workflows/bench-benchmark.yml
+++ b/.github/workflows/bench-benchmark.yml
@@ -28,6 +28,9 @@ on:
         required: false
         default: false
 
+env:
+  REGION: eu-west-1
+
 jobs:
   define-matrix:
     name: Define matrix
@@ -98,7 +101,7 @@ jobs:
           aws: true
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: eu-west-3
+          AWS_REGION: ${{ env.REGION }}
 
       - name: Get Core version
         run: |

--- a/.github/workflows/manual-aws-deploy.yml
+++ b/.github/workflows/manual-aws-deploy.yml
@@ -24,6 +24,10 @@ on:
         description: "Version of Extension Csharp to deploy"
         required: false
         default: ""
+      region:
+        description: "AWS region to deploy to"
+        required: false
+        default: "eu-west-3"
 
 jobs:
   deploy:
@@ -31,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       terraform-output: ${{ steps.deploy.outputs.terraform-output }}
+    env:
+      REGION: ${{ inputs.region }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -41,7 +47,7 @@ jobs:
           terraform: true
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: eu-west-3
+          AWS_REGION: ${{ inputs.region }}
       - if: ${{ inputs.bootstrap }}
         id: bootstrap-deploy
         name: Deploy Bootstrap

--- a/.github/workflows/manual-aws-destroy.yml
+++ b/.github/workflows/manual-aws-destroy.yml
@@ -12,11 +12,17 @@ on:
         type: boolean
         required: false
         default: true
+      region:
+        description: "AWS region to deploy to"
+        required: false
+        default: "eu-west-3"
 
 jobs:
   destroy:
     name: "Destroy"
     runs-on: ubuntu-latest
+    env:
+      REGION: ${{ inputs.region }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -27,7 +33,7 @@ jobs:
           terraform: true
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: eu-west-3
+          AWS_REGION: ${{ inputs.region }}
       - id: destroy
         name: Destroy deployment
         uses: aneoconsulting/ArmoniK.Action.Deploy/destroy@main

--- a/benchmarking/aws.tfvars
+++ b/benchmarking/aws.tfvars
@@ -12,7 +12,7 @@ vpc = {
 
 # AWS EKS
 eks = {
-  cluster_version                = "1.32"
+  cluster_version                = "1.35"
   node_selector                  = { service = "monitoring" }
   cluster_endpoint_public_access = true
   map_roles                      = []
@@ -30,8 +30,7 @@ eks_managed_node_groups = {
   workers = {
     name                        = "workers"
     launch_template_description = "Node group for ArmoniK Compute-plane pods"
-    ami_type                    = "AL2_x86_64"
-    instance_types              = ["c5a.4xlarge"]
+    instance_types              = ["c8a.4xlarge"]
     capacity_type               = "ON_DEMAND" # "SPOT"
     min_size                    = 8
     desired_size                = 8
@@ -56,8 +55,7 @@ eks_managed_node_groups = {
   metrics = {
     name                        = "metrics"
     launch_template_description = "Node group for metrics: Metrics exporter and Prometheus"
-    ami_type                    = "AL2_x86_64"
-    instance_types              = ["c5.large"]
+    instance_types              = ["c8a.large"]
     capacity_type               = "ON_DEMAND"
     min_size                    = 1
     desired_size                = 1
@@ -82,8 +80,7 @@ eks_managed_node_groups = {
   control_plane = {
     name                        = "control-plane"
     launch_template_description = "Node group for ArmoniK Control-plane and Ingress"
-    ami_type                    = "AL2_x86_64"
-    instance_types              = ["c5a.4xlarge"]
+    instance_types              = ["c8a.4xlarge"]
     capacity_type               = "ON_DEMAND"
     min_size                    = 1
     desired_size                = 1
@@ -108,8 +105,7 @@ eks_managed_node_groups = {
   monitoring = {
     name                        = "monitoring"
     launch_template_description = "Node group for monitoring"
-    ami_type                    = "AL2_x86_64"
-    instance_types              = ["c5.large"]
+    instance_types              = ["c8a.large"]
     capacity_type               = "ON_DEMAND"
     min_size                    = 1
     desired_size                = 1
@@ -135,8 +131,7 @@ eks_managed_node_groups = {
   state_database = {
     name                        = "mongodb"
     launch_template_description = "Node group for MongoDB"
-    ami_type                    = "AL2_x86_64"
-    instance_types              = ["c5a.8xlarge"]
+    instance_types              = ["c8a.8xlarge"]
     use_custom_launch_template  = true
     block_device_mappings = {
       xvda = {
@@ -154,8 +149,8 @@ eks_managed_node_groups = {
     }
     capacity_type = "ON_DEMAND"
     min_size      = 1
-    desired_size  = 1
-    max_size      = 1
+    desired_size  = 2
+    max_size      = 2
     labels = {
       service                        = "state-database"
       "node.kubernetes.io/lifecycle" = "ondemand"
@@ -178,7 +173,7 @@ self_managed_node_groups = {
   others = {
     name                        = "others"
     launch_template_description = "Node group for others"
-    instance_type               = "c5.large"
+    instance_type               = "c8a.large"
     min_size                    = 0
     desired_size                = 0
     max_size                    = 5
@@ -210,11 +205,11 @@ self_managed_node_groups = {
     }
     override = [
       {
-        instance_type     = "c5.4xlarge"
+        instance_type     = "c8a.4xlarge"
         weighted_capacity = "1"
       },
       {
-        instance_type     = "c5.2xlarge"
+        instance_type     = "c8a.2xlarge"
         weighted_capacity = "2"
       },
     ]
@@ -241,7 +236,7 @@ keda = {
 elasticache = {
   engine             = "redis"
   engine_version     = "6.x"
-  node_type          = "cache.r4.large"
+  node_type          = "cache.r7g.large"
   num_cache_clusters = 1
 }
 
@@ -255,17 +250,21 @@ mq = {
 
 mongodb = {
   node_selector = { service = "state-database" }
-  replicas      = 2
-  mongodb_resources = {
-    limits = {
-      "cpu"               = "30"
-      "memory"            = "60Gi"
-      "ephemeral-storage" = "20Gi"
-    }
-    requests = {
-      "cpu"               = "14"
-      "memory"            = "29Gi"
-      "ephemeral-storage" = "4Gi"
+  cluster = {
+    replicas = 2
+  }
+  resources = {
+    shards = {
+      limits = {
+        "cpu"               = "30"
+        "memory"            = "60Gi"
+        "ephemeral-storage" = "20Gi"
+      }
+      requests = {
+        "cpu"               = "14"
+        "memory"            = "29Gi"
+        "ephemeral-storage" = "4Gi"
+      }
     }
   }
 }

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,7 +1,7 @@
 {
   "armonik_versions": {
     "armonik":       "2.23.0",
-    "infra":         "0.15.1",
+    "infra":         "0.15.2",
     "infra_plugins": "0.3.0",
     "core":          "0.37.2",
     "api":           "3.28.3",


### PR DESCRIPTION
# Motivation

The AWS benchmarks were not able to run for multiple reasons:
- benchmark/aws.tfvars was not updated to take into account percona mongodb module.
- Stock outs on the europe-west-3 region for c5a machines.

# Description

Fix the persistence configuration for AWS benchmarks.
Upgrade aws.tfvars to match the latest evol.
Change benchmark region.
Upgrade machines to c8/c8a to limit stockouts.

# Testing

https://github.com/aneoconsulting/ArmoniK/actions/runs/22756601407