### PR TITLE
chore: fix utility scripts to connect to db

### DIFF
--- a/tools/mongodb/access-mongo-from-kubernetes-as-admin.sh
+++ b/tools/mongodb/access-mongo-from-kubernetes-as-admin.sh
@@ -2,77 +2,52 @@
 
 set -e
 
+NAMESPACE=${NAMESPACE:-armonik}
+MONGO_SECRET=${MONGO_SECRET:-mongodb-db-ps-secrets}
+MONGO_HOST=${MONGO_HOST:-mongodb-db-ps-rs0.${NAMESPACE}.svc.cluster.local}
+MONGO_PORT=${MONGO_PORT:-27017}
+MONGO_RS=${MONGO_RS:-rs0}
+
 cat <<EOF
-**********************************************************************************************************************
-***** This script allows you to connect to mongo directly from inside the cluster => useful for AWS installation *****
-**********************************************************************************************************************
+Connect to MongoDB as admin inside the cluster.
+Namespace:  $NAMESPACE
+Host:       $MONGO_HOST:$MONGO_PORT  (rs=$MONGO_RS)
+Secret:     $MONGO_SECRET
 
-1 - Firstly you have to connect to db :
-  use database
+1 - Connect to a database:
+      use <database>
+2 - Example queries:
+      db.TaskData.find().limit(3).pretty()
+      db.TaskData.find({ SessionId: { \$eq: '<id>' } }).pretty()
+      db.TaskData.find({ SessionId: { \$eq: '<id>' }, ExpectedOutputIds: { \$eq: '<id>' } }).pretty()
 
-2 - You can execute requests ex :
-- Display all TaskData :
-  db.TaskData.find().limit(3).pretty()
-- Filter by  session / output :
-  db.TaskData.find({ SessionId: { \$eq : '7eafe4e3-0aa2-46ef-8ce6-bf9e365c5449' }, ExpectedOutputIds: { \$eq : 'a600dca5-b672-4177-9b4a-880dbcefee4e'}}).pretty()
-
-more informations here : https://www.mongodb.com/docs/manual/reference/method/db.collection.find/
-
+Docs: https://www.mongodb.com/docs/manual/reference/method/db.collection.find/
 EOF
 
-kubectl run -it --rm -n armonik mongoshclient --image=rtsp/mongosh --overrides='
+kubectl run -it --rm -n "$NAMESPACE" mongoshclient \
+  --image=mongo:8 \
+  --restart=Never \
+  --overrides='
 {
   "apiVersion": "v1",
   "kind": "Pod",
-  "metadata": {
-    "creationTimestamp": null,
-    "labels": {
-      "run": "mongoshclient"
-    },
-    "name": "mongoshclient",
-    "namespace": "armonik"
-  },
+  "metadata": { "name": "mongoshclient", "namespace": "'"$NAMESPACE"'" },
   "spec": {
-    "containers": [
-      {
-        "name": "mongosh",
-        "image": "rtsp/mongosh",
-        "stdin": true,
-        "tty": true,
-        "command": [
-          "bash",
-          "-c"
-        ],
-        "args": [
-          "mongosh -u $MONGO_ADMIN_USERNAME -p $MONGO_ADMIN_PASSWORD 'mongodb://mongodb-db-ps-rs0.armonik.svc.cluster.local:27017/admin?replicaSet=rs0'"
-        ],
-        "env": [
-          {
-            "name": "MONGO_ADMIN_USERNAME",
-            "valueFrom": {
-              "secretKeyRef": {
-                "name": "mongodb-db-ps-secrets",
-                "key": "MONGODB_DATABASE_ADMIN_USER"
-              }
-            }
-          },
-          {
-            "name": "MONGO_ADMIN_PASSWORD",
-            "valueFrom": {
-              "secretKeyRef": {
-                "name": "mongodb-db-ps-secrets",
-                "key": "MONGODB_DATABASE_ADMIN_PASSWORD"
-              }
-            }
-          }
-        ],
-        "resources": {}
-      }
-    ],
-    "volumes": [],
-    "dnsPolicy": "ClusterFirst",
-    "restartPolicy": "Always"
-  },
-  "status": {}
-}
-'
+    "containers": [{
+      "name": "mongosh",
+      "image": "mongo:8",
+      "stdin": true,
+      "tty": true,
+      "command": ["bash", "-c"],
+      "args": ["mongosh \"mongodb://${MONGO_ADMIN_USERNAME}:${MONGO_ADMIN_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/admin?replicaSet=${MONGO_RS}\""],
+      "env": [
+        { "name": "MONGO_ADMIN_USERNAME", "valueFrom": { "secretKeyRef": { "name": "'"$MONGO_SECRET"'", "key": "MONGODB_DATABASE_ADMIN_USER" } } },
+        { "name": "MONGO_ADMIN_PASSWORD", "valueFrom": { "secretKeyRef": { "name": "'"$MONGO_SECRET"'", "key": "MONGODB_DATABASE_ADMIN_PASSWORD" } } },
+        { "name": "MONGO_HOST",           "value": "'"$MONGO_HOST"'" },
+        { "name": "MONGO_PORT",           "value": "'"$MONGO_PORT"'" },
+        { "name": "MONGO_RS",             "value": "'"$MONGO_RS"'" }
+      ]
+    }],
+    "restartPolicy": "Never"
+  }
+}'

--- a/tools/mongodb/access-mongo-from-kubernetes-as-admin.sh
+++ b/tools/mongodb/access-mongo-from-kubernetes-as-admin.sh
@@ -44,45 +44,32 @@ kubectl run -it --rm -n armonik mongoshclient --image=rtsp/mongosh --overrides='
           "-c"
         ],
         "args": [
-          "mongosh --tlsCAFile /mongodb/chain.pem --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD mongodb+srv://mongodb-armonik-headless.armonik.svc.cluster.local/"
+          "mongosh -u $MONGO_ADMIN_USERNAME -p $MONGO_ADMIN_PASSWORD 'mongodb://mongodb-db-ps-rs0.armonik.svc.cluster.local:27017/admin?replicaSet=rs0'"
         ],
         "env": [
           {
-            "name": "MONGO_INITDB_ROOT_USERNAME",
+            "name": "MONGO_ADMIN_USERNAME",
             "valueFrom": {
               "secretKeyRef": {
-                "name": "mongodb-admin",
-                "key": "username"
+                "name": "mongodb-db-ps-secrets",
+                "key": "MONGODB_DATABASE_ADMIN_USER"
               }
             }
           },
           {
-            "name": "MONGO_INITDB_ROOT_PASSWORD",
+            "name": "MONGO_ADMIN_PASSWORD",
             "valueFrom": {
               "secretKeyRef": {
-                "name": "mongodb-admin",
-                "key": "password"
+                "name": "mongodb-db-ps-secrets",
+                "key": "MONGODB_DATABASE_ADMIN_PASSWORD"
               }
             }
-          }
-        ],
-        "volumeMounts": [
-          {
-            "name": "mongodb-secret-volume",
-            "mountPath": "/mongodb/"
           }
         ],
         "resources": {}
       }
     ],
-    "volumes": [
-      {
-        "name": "mongodb-secret-volume",
-        "secret": {
-          "secretName": "mongodb"
-        }
-      }
-    ],
+    "volumes": [],
     "dnsPolicy": "ClusterFirst",
     "restartPolicy": "Always"
   },

--- a/tools/mongodb/access-mongo-from-kubernetes-as-user.sh
+++ b/tools/mongodb/access-mongo-from-kubernetes-as-user.sh
@@ -41,45 +41,23 @@ kubectl run -it --rm -n armonik mongoshclient --image=rtsp/mongosh --overrides='
           "-c"
         ],
         "args": [
-          "mongosh --tlsCAFile /mongodb/chain.pem --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls -u $MONGO_USERNAME -p $MONGO_USER_PASSWORD mongodb+srv://mongodb-armonik-headless.armonik.svc.cluster.local/database"
+          "mongosh $MONGODB_URI"
         ],
         "env": [
           {
-            "name": "MONGO_USERNAME",
+            "name": "MONGODB_URI",
             "valueFrom": {
               "secretKeyRef": {
-                "name": "mongodb-user",
-                "key": "username"
+                "name": "mongodb-connection-string",
+                "key": "uri"
               }
             }
-          },
-          {
-            "name": "MONGO_USER_PASSWORD",
-            "valueFrom": {
-              "secretKeyRef": {
-                "name": "mongodb-user",
-                "key": "password"
-              }
-            }
-          }
-        ],
-        "volumeMounts": [
-          {
-            "name": "mongodb-secret-volume",
-            "mountPath": "/mongodb/"
           }
         ],
         "resources": {}
       }
     ],
-    "volumes": [
-      {
-        "name": "mongodb-secret-volume",
-        "secret": {
-          "secretName": "mongodb"
-        }
-      }
-    ],
+    "volumes": [],
     "dnsPolicy": "ClusterFirst",
     "restartPolicy": "Always"
   },

--- a/tools/mongodb/access-mongo-from-kubernetes-as-user.sh
+++ b/tools/mongodb/access-mongo-from-kubernetes-as-user.sh
@@ -2,65 +2,43 @@
 
 set -e
 
+NAMESPACE=${NAMESPACE:-armonik}
+MONGO_SECRET=${MONGO_SECRET:-mongodb-connection-string}
+
 cat <<EOF
-**********************************************************************************************************************
-***** This script allows you to connect to mongo directly from inside the cluster => useful for AWS installation *****
-**********************************************************************************************************************
+Connect to MongoDB inside the cluster.
+Namespace:  $NAMESPACE
+Secret:     $MONGO_SECRET
 
-- You can execute requests ex :
-- Display all TaskData :
+Example queries:
   db.TaskData.find().limit(3).pretty()
-- Filter by  session / output :
-  db.TaskData.find({ SessionId: { \$eq : '7eafe4e3-0aa2-46ef-8ce6-bf9e365c5449' }, ExpectedOutputIds: { \$eq : 'a600dca5-b672-4177-9b4a-880dbcefee4e'}}).pretty()
+  db.TaskData.find({ SessionId: { \$eq: '<id>' } }).pretty()
+  db.TaskData.find({ SessionId: { \$eq: '<id>' }, ExpectedOutputIds: { \$eq: '<id>' } }).pretty()
 
-more informations here : https://www.mongodb.com/docs/manual/reference/method/db.collection.find/
-
+Docs: https://www.mongodb.com/docs/manual/reference/method/db.collection.find/
 EOF
 
-kubectl run -it --rm -n armonik mongoshclient --image=rtsp/mongosh --overrides='
+kubectl run -it --rm -n "$NAMESPACE" mongoshclient \
+  --image=mongo:8 \
+  --restart=Never \
+  --overrides='
 {
   "apiVersion": "v1",
   "kind": "Pod",
-  "metadata": {
-    "creationTimestamp": null,
-    "labels": {
-      "run": "mongoshclient"
-    },
-    "name": "mongoshclient",
-    "namespace": "armonik"
-  },
+  "metadata": { "name": "mongoshclient", "namespace": "'"$NAMESPACE"'" },
   "spec": {
-    "containers": [
-      {
-        "name": "mongosh",
-        "image": "rtsp/mongosh",
-        "stdin": true,
-        "tty": true,
-        "command": [
-          "bash",
-          "-c"
-        ],
-        "args": [
-          "mongosh $MONGODB_URI"
-        ],
-        "env": [
-          {
-            "name": "MONGODB_URI",
-            "valueFrom": {
-              "secretKeyRef": {
-                "name": "mongodb-connection-string",
-                "key": "uri"
-              }
-            }
-          }
-        ],
-        "resources": {}
-      }
-    ],
-    "volumes": [],
-    "dnsPolicy": "ClusterFirst",
-    "restartPolicy": "Always"
-  },
-  "status": {}
-}
-'
+    "containers": [{
+      "name": "mongosh",
+      "image": "mongo:8",
+      "stdin": true,
+      "tty": true,
+      "command": ["bash", "-c"],
+      "args": ["mongosh \"$MONGODB_URI\""],
+      "env": [{
+        "name": "MONGODB_URI",
+        "valueFrom": { "secretKeyRef": { "name": "'"$MONGO_SECRET"'", "key": "uri" } }
+      }]
+    }],
+    "restartPolicy": "Never"
+  }
+}'


### PR DESCRIPTION
  # Motivation                                                                                       
                                                                                                     
  The MongoDB utility scripts used to connect to the database from Kubernetes were referencing       
  outdated secret names and connection parameters that no longer match the current infrastructure    
  setup. This caused the scripts to fail when attempting to connect.                                 
                  
  # Description

  Updates two utility scripts to align with the current MongoDB deployment secrets and connection    
  conventions (percona operator). 
                                                                                                     
  # Testing       

  Scripts were tested manually against a running localhost ArmoniK deployment to verify successful   
  connection as both admin and user roles.
                                                                                                     
  # Impact        

  These are development/ops utility scripts only; there is no impact on the ArmoniK runtime or its   
  configuration. 

  # Additional Information

  Both scripts now follow the same pattern: env-var overrides with safe defaults,
  single-quoted JSON `--overrides` block with `'"$VAR"'` splicing for host-resolved values,              
  and all sensitive variable expansion deferred to inside the container.                                                                                   
  
  # Checklist                                                                                        
                  
  - [x] My code adheres to the coding and style guidelines of the project.                           
  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in hard-to-understand areas.                          
  - [ ] I have made corresponding changes to the documentation.                                      
  - [x] I have thoroughly tested my modifications and added tests when necessary.
  - [x] Tests pass locally and in the CI.                                                            
  - [ ] I have assessed the performance impact of my modifications.   