### PR TITLE
chore(versions): bump ArmoniK versions to 2.24.0

### DIFF
--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,15 +1,15 @@
 {
   "armonik_versions": {
-    "armonik":       "2.23.0",
+    "armonik":       "2.24.0",
     "infra":         "0.15.2",
     "infra_plugins": "0.3.0",
-    "core":          "0.37.2",
-    "api":           "3.28.3",
-    "gui":           "0.15.1",
+    "core":          "0.39.0",
+    "api":           "3.29.0",
+    "gui":           "0.15.2",
     "extcsharp":     "0.21.2",
-    "extcpp":        "0.4.4",
-    "extjava":       "0.1.2",
-    "samples":       "2.23.0"
+    "extcpp":        "0.5.0",
+    "extjava":       "0.1.3",
+    "samples":       "2.24.0"
   },
   "armonik_images": {
     "armonik": [


### PR DESCRIPTION
# Motivation

Routine version bump to align all ArmoniK components with the 2.24.0 release cycle.

# Description

Updates component versions in `versions.tfvars.json`:

| Component  | Old      | New      |
|------------|----------|----------|
| armonik    | 2.23.0   | 2.24.0   |
| core       | 0.37.2   | 0.39.0   |
| api        | 3.28.3   | 3.29.0   |
| gui        | 0.15.1   | 0.15.2   |
| extcpp     | 0.4.4    | 0.5.0    |
| extjava    | 0.1.2    | 0.1.3    |
| samples    | 2.23.0   | 2.24.0   |

# Testing

No functional changes — version strings only. CI will validate image availability and compatibility.

# Impact

All ArmoniK deployments using this configuration will pull the new component versions. No breaking changes expected; this is an aligned version bump across the ecosystem.

# Additional Information

`infra`, `infra_plugins`, and `extcsharp` versions are unchanged.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.