### PR TITLE
chore(renovate): enforce semantic commits and add PR body template matching project convention

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,9 @@
     ":semanticCommitTypeAll(chore)",
     "helpers:pinGitHubActionDigests"
   ],
+  "semanticCommits": "enabled",
   "rangeStrategy": "bump",
+  "prBodyTemplate": "# Motivation\n\nAutomated dependency update by Renovate bot.\n\n# Description\n\n{{{table}}}{{{notes}}}\n\n# Testing\n\nThis is an automated dependency update. No functional changes are expected.\n\n# Impact\n\n{{{changelogs}}}\n\n# Additional Information\n\n{{{warnings}}}{{{errors}}}{{{controls}}}This PR was generated automatically by [Renovate](https://docs.renovatebot.com/).\n\n# Checklist\n\n- [x] My code adheres to the coding and style guidelines of the project.\n- [x] I have performed a self-review of my code.\n- [ ] I have commented my code, particularly in hard-to-understand areas.\n- [ ] I have made corresponding changes to the documentation.\n- [x] I have thoroughly tested my modifications and added tests when necessary.\n- [x] Tests pass locally and in the CI.\n- [x] I have assessed the performance impact of my modifications.",
   "packageRules": [
     {
       "groupName": "npm packages",
@@ -35,6 +37,6 @@
       "matchDatasources": [
         "github-tags"
       ]
-    },
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   ],
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",
-  "prBodyTemplate": "# Motivation\n\nAutomated dependency update by Renovate bot.\n\n# Description\n\n{{{table}}}{{{notes}}}\n\n# Testing\n\nThis is an automated dependency update. No functional changes are expected.\n\n# Impact\n\n{{{changelogs}}}\n\n# Additional Information\n\n{{{warnings}}}{{{errors}}}{{{controls}}}This PR was generated automatically by [Renovate](https://docs.renovatebot.com/).\n\n# Checklist\n\n- [x] My code adheres to the coding and style guidelines of the project.\n- [x] I have performed a self-review of my code.\n- [ ] I have commented my code, particularly in hard-to-understand areas.\n- [ ] I have made corresponding changes to the documentation.\n- [x] I have thoroughly tested my modifications and added tests when necessary.\n- [x] Tests pass locally and in the CI.\n- [x] I have assessed the performance impact of my modifications.",
+  "prBodyTemplate": "# Motivation\n\nAutomated dependency update by Renovate bot.\n\n# Description\n\n{{{table}}}{{{notes}}}\n\n# Testing\n\nThis is an automated dependency update. No functional changes are expected.\n\n# Impact\n\n{{{changelogs}}}\n\n# Additional Information\n\n{{{warnings}}}{{{errors}}}{{{controls}}}This PR was generated automatically by [Renovate](https://docs.renovatebot.com/).",
   "packageRules": [
     {
       "groupName": "npm packages",


### PR DESCRIPTION
# Motivation

  Renovate-generated PRs were failing CI because the PR title linter (`amannn/action-semantic-pull-request`) could not guarantee a conventional commits format when `semanticCommits` was left on `"auto"`.
  Additionally, the PR body was using Renovate's default template, which does not match the project's required structure.

  # Description

  Two changes to `renovate.json`:

  - **`"semanticCommits": "enabled"`**: `config:base` sets `"semanticCommits": "auto"`, which relies on repo heuristics to decide whether to prefix titles. Making it explicit ensures every Renovate PR title is
  always generated as `chore(deps): ...`, which passes the conventional commits linter.
  - **`prBodyTemplate`**: Wraps Renovate's update content (`{{{table}}}`, `{{{notes}}}`, `{{{changelogs}}}`, `{{{warnings}}}`, `{{{errors}}}`, `{{{controls}}}`) inside the project's required section headers
  (Motivation, Description, Testing, Impact, Additional Information, Checklist).

  Also removed the trailing comma after the last `packageRules` entry (technically invalid JSON).

  # Testing

  Open a new Renovate PR and verify:
  - The PR title follows `chore(scope): ...` and passes the "Lint PR" workflow.
  - The PR body contains all required sections from the project template.

  # Impact

  No functional change to ArmoniK itself. Only affects the format of future automated dependency update PRs.

  # Additional Information

  N/A

  # Checklist

  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [ ] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have made corresponding changes to the documentation.
  - [x] I have thoroughly tested my modifications and added tests when necessary.
  - [x] Tests pass locally and in the CI.
  - [x] I have assessed the performance impact of my modifications.
