### PR TITLE
chore: upgrade ArmoniK component versions and enable readiness probe by default

### DIFF
--- a/infrastructure/quick-deploy/aws/variables.tf
+++ b/infrastructure/quick-deploy/aws/variables.tf
@@ -743,6 +743,7 @@ variable "control_plane" {
     # KEDA scaler
     hpa               = optional(any)
     default_partition = string
+    readiness_probe   = optional(bool, true)
   })
 }
 

--- a/infrastructure/quick-deploy/gcp/variables.tf
+++ b/infrastructure/quick-deploy/gcp/variables.tf
@@ -420,6 +420,7 @@ variable "control_plane" {
     # KEDA scaler
     hpa               = optional(any)
     default_partition = string
+    readiness_probe   = optional(bool, true)
   })
 }
 

--- a/infrastructure/quick-deploy/localhost/variables.tf
+++ b/infrastructure/quick-deploy/localhost/variables.tf
@@ -441,6 +441,7 @@ variable "control_plane" {
     # KEDA scaler
     hpa               = optional(any)
     default_partition = string
+    readiness_probe   = optional(bool, true)
   })
 }
 

--- a/versions.tfvars.json
+++ b/versions.tfvars.json
@@ -1,14 +1,14 @@
 {
   "armonik_versions": {
     "armonik":       "2.24.0",
-    "infra":         "0.15.2",
-    "infra_plugins": "0.3.0",
-    "core":          "0.39.0",
-    "api":           "3.29.0",
+    "infra":         "0.15.3",
+    "infra_plugins": "0.3.1",
+    "core":          "0.40.1",
+    "api":           "3.29.1",
     "gui":           "0.15.2",
     "extcsharp":     "0.21.2",
-    "extcpp":        "0.5.2",
-    "extjava":       "0.1.3",
+    "extcpp":        "0.5.4",
+    "extjava":       "0.1.4",
     "samples":       "2.24.0"
   },
   "armonik_images": {


### PR DESCRIPTION
# Motivation

The ArmoniK deployment tracked outdated versions of several core components. This change bumps those versions to their latest releases so deployments pick up the corresponding fixes and improvements. It also enables the control plane readiness probe by default to improve rollout safety.

# Description

- Bump ArmoniK component versions in `versions.tfvars.json`:
  - `infra`: `0.15.2` -> `0.15.3`
  - `infra_plugins`: `0.3.0` -> `0.3.1`
  - `core`: `0.39.0` -> `0.40.1`
  - `api`: `3.29.0` -> `3.29.1`
  - `extcpp`: `0.5.2` -> `0.5.4`
  - `extjava`: `0.1.3` -> `0.1.4`
- Add a `readiness_probe` option (`optional(bool, true)`) to the `control_plane` variable across the AWS, GCP, and localhost quick-deploy configurations, enabling the readiness probe by default.

# Testing

No automated tests added; changes are configuration/version bumps. Validation relies on the existing CI deployment pipelines exercising the quick-deploy stacks with the new versions and the default readiness probe enabled.

# Impact

- Deployments will use the upgraded component versions.
- The control plane readiness probe is now enabled by default. Because the new variable defaults to `true`, existing configurations that do not set it explicitly will start using the readiness probe. This can be disabled by setting `readiness_probe = false` in the `control_plane` block. In particular, previous versions of core do not implement the readiness probe, and would fail to deploy unless the probe is disabled.

# Additional Information

The `readiness_probe` option was added consistently to the AWS, GCP, and localhost variable definitions to keep the three quick-deploy stacks aligned.